### PR TITLE
Update channel_id terminology for consistency in documentation

### DIFF
--- a/src/nanomoni/domain/vendor/entities.py
+++ b/src/nanomoni/domain/vendor/entities.py
@@ -139,7 +139,7 @@ class OffChainTx(DatetimeSerializerMixin, BaseModel):
 class PaywordState(DatetimeSerializerMixin, BaseModel):
     """Latest PayWord payment state (monotonic counter + token)."""
 
-    channel_id: str = Field(..., description="Payment channel computed ID")
+    channel_id: str = Field(..., description="Payment channel identifier")
     k: int = Field(..., ge=0, description="Monotonic PayWord counter")
     token_b64: str = Field(..., description="Base64 token for this k (preimage)")
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
@@ -148,7 +148,7 @@ class PaywordState(DatetimeSerializerMixin, BaseModel):
 class PaytreeState(DatetimeSerializerMixin, BaseModel):
     """Latest PayTree payment state (monotonic index + Merkle proof)."""
 
-    channel_id: str = Field(..., description="Payment channel computed ID")
+    channel_id: str = Field(..., description="Payment channel identifier")
     i: int = Field(..., ge=0, description="Monotonic PayTree index")
     leaf_b64: str = Field(..., description="Base64-encoded leaf hash")
     siblings_b64: list[str] = Field(

--- a/tests/e2e/helpers/vendor_client.py
+++ b/tests/e2e/helpers/vendor_client.py
@@ -90,7 +90,7 @@ class VendorTestClient:
         Submit a payment to the vendor.
 
         Args:
-            channel_id: Payment channel computed ID
+            channel_id: Payment channel identifier
             payment_envelope: Signed payment envelope from client
 
         Returns:
@@ -111,7 +111,7 @@ class VendorTestClient:
         Request closure of a payment channel.
 
         Args:
-            channel_id: Payment channel computed ID
+            channel_id: Payment channel identifier
         """
         dto = CloseChannelDTO(channel_id=channel_id)
         response = await self._request(


### PR DESCRIPTION
- Changed references of "Payment channel computed ID" to "Payment channel identifier" in the PaywordState and PaytreeState classes.
- Updated corresponding documentation in the VendorTestClient to reflect the new terminology, enhancing clarity and consistency across the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified channel identifier field descriptions across payment state documentation for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->