### PR TITLE
PayTree Child-Pair protocol + merkle node repository refactor

### DIFF
--- a/bench-plotter/src/bench_plotter/metric_queries/__init__.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/__init__.py
@@ -10,6 +10,10 @@ from .paytree_first_opt import (
     get_paytree_first_opt_charts,
     LATENCY_BUCKET_METRIC as _PAYTREE_FIRST_OPT_METRIC,
 )
+from .paytree_child_pair import (
+    get_paytree_child_pair_charts,
+    LATENCY_BUCKET_METRIC as _PAYTREE_CHILD_PAIR_METRIC,
+)
 
 # Single source of truth for mode -> latency-histogram bucket metric name,
 # consumed by pipeline/latency.py to build the steady-state latency box/ECDF/
@@ -19,6 +23,7 @@ LATENCY_BUCKET_METRIC_BY_MODE: Dict[str, str] = {
     "payword": _PAYWORD_METRIC,
     "paytree": _PAYTREE_METRIC,
     "paytree_first_opt": _PAYTREE_FIRST_OPT_METRIC,
+    "paytree_child_pair": _PAYTREE_CHILD_PAIR_METRIC,
 }
 
 # mode -> chart getter: the one place that knows how to turn a mode name into
@@ -28,6 +33,7 @@ _MODE_CHART_GETTERS = {
     "payword": get_payword_charts,
     "paytree": get_paytree_charts,
     "paytree_first_opt": get_paytree_first_opt_charts,
+    "paytree_child_pair": get_paytree_child_pair_charts,
 }
 
 

--- a/bench-plotter/src/bench_plotter/metric_queries/paytree_child_pair.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/paytree_child_pair.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""paytree_child_pair payment mode PromQL metric queries."""
+
+from typing import Any, Dict, List
+
+# Single source of truth for this mode's latency-histogram bucket metric name,
+# consumed by pipeline/latency.py to build the steady-state latency box/ECDF/
+# violin queries instead of duplicating the string there.
+LATENCY_BUCKET_METRIC = (
+    "paytree_child_pair_payment_request_duration_milliseconds_bucket"
+)
+
+# Paytree-child-pair-specific TPS metrics charts
+PAYTREE_CHILD_PAIR_CHARTS: List[Dict[str, Any]] = [
+    {
+        "title": "Vendor Payment TPS (success)",
+        "section": "tps_metrics",
+        "queries": [
+            {
+                "promql": 'rate(paytree_child_pair_payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "legend": "Paytree Child-Pair",
+            },
+        ],
+    },
+    {
+        "title": "Vendor Payment Duration Quantiles (ms)",
+        "section": "tps_metrics",
+        "queries": [
+            {
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "legend": "Paytree Child-Pair P99",
+            },
+            {
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "legend": "Paytree Child-Pair P95",
+            },
+            {
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "legend": "Paytree Child-Pair P50",
+            },
+        ],
+    },
+]
+
+
+def get_paytree_child_pair_charts() -> List[Dict[str, Any]]:
+    """Return paytree_child_pair-specific charts."""
+    return PAYTREE_CHILD_PAIR_CHARTS

--- a/bench-plotter/src/bench_plotter/pipeline/naming.py
+++ b/bench-plotter/src/bench_plotter/pipeline/naming.py
@@ -45,10 +45,17 @@ def is_tps_chart(chart_title: str, legend_format: str, expr: str) -> bool:
 
 
 def extract_payment_mode_from_expr(expr: str) -> str:
-    """Derive the payment mode from a PromQL metric prefix."""
+    """Derive the payment mode from a PromQL metric prefix.
+
+    Order matters: more specific "paytree_*" prefixes must be checked before
+    the bare "paytree_" one, since e.g. "paytree_child_pair_..." and
+    "paytree_first_opt_..." metric names both contain "paytree_" as a substring.
+    """
     ex = expr.lower()
     if "paytree_first_opt_" in ex:
         return "paytree_first_opt"
+    if "paytree_child_pair_" in ex:
+        return "paytree_child_pair"
     if "paytree_" in ex:
         return "paytree"
     if "payword_" in ex:

--- a/bench-plotter/src/bench_plotter/sweep/aggregate.py
+++ b/bench-plotter/src/bench_plotter/sweep/aggregate.py
@@ -40,7 +40,13 @@ _MAX_CONCURRENCY = 8
 
 # Stable visual identity per payment mode (sorted-mode index into the palette).
 _MODE_MARKERS = ("o", "s", "^", "D", "v", "P", "X", "*")
-_KNOWN_MODES = ("paytree", "paytree_first_opt", "payword", "signature")
+_KNOWN_MODES = (
+    "paytree",
+    "paytree_first_opt",
+    "paytree_child_pair",
+    "payword",
+    "signature",
+)
 
 
 def _mode_style(mode: str) -> Dict[str, str]:

--- a/envs/example.client.sh
+++ b/envs/example.client.sh
@@ -19,6 +19,9 @@ export CLIENT_CHANNEL_AMOUNT=10000000
 # - "signature": send signed cumulative_owed_amount updates (existing behavior)
 # - "payword": send PayWord hash-chain tokens (k, token_b64)
 # - "paytree": send PayTree Merkle proof payments (i, leaf_b64, siblings_b64[])
+# - "paytree_first_opt": PayTree with a smaller first-payment proof
+# - "paytree_child_pair": PayTree child-pair revelation (k, left_b64, right_b64);
+#   reuses CLIENT_PAYTREE_MAX_I/CLIENT_PAYTREE_UNIT_VALUE (max_i is the max k here)
 export CLIENT_PAYMENT_MODE="payword"
 
 # PayWord mode mental model:

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -100,6 +100,16 @@ run_paytree_first_opt() {
   run_mode "paytree_first_opt"
 }
 
+run_paytree_child_pair() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="paytree_child_pair"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
+  export CLIENT_CHANNEL_AMOUNT=10000000
+  run_mode "paytree_child_pair"
+}
+
 run_payword() {
   source envs/client.env.sh
   export CLIENT_PAYMENT_MODE="payword"
@@ -126,6 +136,8 @@ for tps in "${TPS_VALUES[@]}"; do
   run_paytree
   sleep "$SLEEP_TIME"
   run_paytree_first_opt
+  sleep "$SLEEP_TIME"
+  run_paytree_child_pair
   sleep "$SLEEP_TIME"
   run_payword
   sleep "$SLEEP_TIME"

--- a/scripts/benchmark_paytree_child_pair.sh
+++ b/scripts/benchmark_paytree_child_pair.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+: "${BENCHMARK_COUNT_VAR:=1048576}"
+
+source envs/client.env.sh
+export CLIENT_PAYMENT_MODE="paytree_child_pair"
+export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+# Ensure channel_amount >= (max_i * unit_value) with some headroom for remainder
+export CLIENT_CHANNEL_AMOUNT=10000000
+
+docker compose up --no-deps --abort-on-container-exit --exit-code-from client client
+docker compose stop client >/dev/null 2>&1 || true
+docker compose rm -fsv client >/dev/null 2>&1 || true

--- a/src/nanomoni/api/issuer_api/app.py
+++ b/src/nanomoni/api/issuer_api/app.py
@@ -18,6 +18,7 @@ from ...envs.issuer_env import get_settings
 from ...infrastructure.scripts import ISSUER_SCRIPTS
 from .dependencies import get_store_dependency
 from .routers import (
+    paytree_child_pair_channels,
     paytree_first_opt_channels,
     paytree_std_channels,
     payment_channel,
@@ -69,6 +70,7 @@ def create_issuer_app() -> FastAPI:
     app.include_router(payword_channels.router, prefix="/api/v1/issuer")
     app.include_router(paytree_std_channels.router, prefix="/api/v1/issuer")
     app.include_router(paytree_first_opt_channels.router, prefix="/api/v1/issuer")
+    app.include_router(paytree_child_pair_channels.router, prefix="/api/v1/issuer")
 
     @app.get("/")
     async def root() -> dict[str, str]:

--- a/src/nanomoni/api/issuer_api/dependencies.py
+++ b/src/nanomoni/api/issuer_api/dependencies.py
@@ -87,3 +87,12 @@ def get_paytree_first_opt_channel_service() -> PaytreeChannelService:
     return PaytreeChannelService(
         account_repo, channel_repo, settings.issuer_private_key
     )
+
+
+def get_paytree_child_pair_channel_service() -> PaytreeChannelService:
+    account_repo = get_account_repository()
+    channel_repo = get_payment_channel_repository()
+    settings = get_settings_dependency()
+    return PaytreeChannelService(
+        account_repo, channel_repo, settings.issuer_private_key
+    )

--- a/src/nanomoni/api/issuer_api/routers/paytree_child_pair_channels.py
+++ b/src/nanomoni/api/issuer_api/routers/paytree_child_pair_channels.py
@@ -1,0 +1,76 @@
+"""PayTree child-pair channel API routes (Issuer).
+
+Opening/reading a child-pair channel reuses the same PayTree commitment shape
+(root/unit_value/max) as std and first-opt — only per-payment verification
+and settlement differ, so this router shares `PaytreeChannelService.open_channel`
+/ `get_channel` and adds a dedicated child-pair settlement endpoint.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ....application.issuer.dtos import (
+    GetPaymentChannelRequestDTO,
+    OpenChannelRequestDTO,
+    CloseChannelResponseDTO,
+)
+from ....application.issuer.paytree_dtos import (
+    PaytreeChildPairSettlementRequestDTO,
+    PaytreeOpenChannelResponseDTO,
+    PaytreePaymentChannelResponseDTO,
+)
+from ....application.issuer.use_cases.paytree_channel import PaytreeChannelService
+from ..dependencies import get_paytree_child_pair_channel_service
+
+
+router = APIRouter(
+    prefix="/channels/paytree/child-pair", tags=["channels", "paytree-child-pair"]
+)
+
+
+@router.post(
+    "",
+    response_model=PaytreeOpenChannelResponseDTO,
+    status_code=status.HTTP_201_CREATED,
+)
+async def open_paytree_child_pair_channel(
+    payload: OpenChannelRequestDTO,
+    service: PaytreeChannelService = Depends(get_paytree_child_pair_channel_service),
+) -> PaytreeOpenChannelResponseDTO:
+    try:
+        return await service.open_channel(payload)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post(
+    "/{channel_id}/settlements",
+    response_model=CloseChannelResponseDTO,
+    status_code=status.HTTP_200_OK,
+)
+async def settle_paytree_child_pair_channel(
+    channel_id: str,
+    payload: PaytreeChildPairSettlementRequestDTO,
+    service: PaytreeChannelService = Depends(get_paytree_child_pair_channel_service),
+) -> CloseChannelResponseDTO:
+    try:
+        return await service.settle_channel_child_pair(channel_id, payload)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get(
+    "/{channel_id}",
+    response_model=PaytreePaymentChannelResponseDTO,
+    status_code=status.HTTP_200_OK,
+)
+async def get_paytree_child_pair_channel(
+    channel_id: str,
+    service: PaytreeChannelService = Depends(get_paytree_child_pair_channel_service),
+) -> PaytreePaymentChannelResponseDTO:
+    payload = GetPaymentChannelRequestDTO(channel_id=channel_id)
+    try:
+        return await service.get_channel(payload)
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(err))

--- a/src/nanomoni/api/vendor_api/app.py
+++ b/src/nanomoni/api/vendor_api/app.py
@@ -25,6 +25,7 @@ from ...infrastructure.scripts import VENDOR_SCRIPTS
 from .dependencies import get_key_value_store_dependency
 from .routers import (
     payments,
+    paytree_child_pair_payments,
     paytree_first_opt_payments,
     paytree_std_payments,
     payword_payments,
@@ -86,6 +87,7 @@ def create_app() -> FastAPI:
     app.include_router(payword_payments.router, prefix="/api/v1/vendor")
     app.include_router(paytree_std_payments.router, prefix="/api/v1/vendor")
     app.include_router(paytree_first_opt_payments.router, prefix="/api/v1/vendor")
+    app.include_router(paytree_child_pair_payments.router, prefix="/api/v1/vendor")
 
     @app.get("/")
     async def root() -> dict[str, str]:

--- a/src/nanomoni/api/vendor_api/dependencies.py
+++ b/src/nanomoni/api/vendor_api/dependencies.py
@@ -13,6 +13,9 @@ from ...application.vendor.use_cases.paytree_std_payment import PaytreeStdPaymen
 from ...application.vendor.use_cases.paytree_first_opt_payment import (
     PaytreeFirstOptPaymentService,
 )
+from ...application.vendor.use_cases.paytree_child_pair_payment import (
+    PaytreeChildPairPaymentService,
+)
 from ...application.vendor.use_cases.task import TaskService
 from ...application.vendor.use_cases.user import UserService
 from ...domain.shared import IssuerClientFactory
@@ -24,6 +27,7 @@ from ...infrastructure.storage import KeyValueStore, RedisKeyValueStore
 from ...application.shared.paytree_scheme import (
     PaytreeStdCryptoScheme,
     PaytreeFirstOptCryptoScheme,
+    PaytreeChildPairCryptoScheme,
 )
 from ...application.shared.payword_scheme import PaywordCryptoScheme
 from ...domain.vendor.payment_channel_repository import SignatureRepository
@@ -162,6 +166,27 @@ async def get_paytree_first_opt_payment_service(
         issuer_client_factory=issuer_client_factory,
         vendor_public_key_der_b64=settings.vendor_public_key_der_b64,
         crypto_scheme=PaytreeFirstOptCryptoScheme(),
+        node_repo=node_repo,
+        vendor_private_key_pem=settings.vendor_private_key_pem,
+    )
+
+
+async def get_paytree_child_pair_payment_service(
+    request: Request,
+) -> PaytreeChildPairPaymentService:
+    """Get PayTree child-pair payment service."""
+    settings = get_settings_dependency()
+    issuer_client_factory = _create_issuer_client_factory(
+        settings.issuer_base_url,
+        session=request.app.state.issuer_session,
+    )
+    store = get_key_value_store_dependency()
+    node_repo = MerkleNodeRepositoryImpl(store)
+    return PaytreeChildPairPaymentService(
+        payment_repository=get_payment_repository(),
+        issuer_client_factory=issuer_client_factory,
+        vendor_public_key_der_b64=settings.vendor_public_key_der_b64,
+        crypto_scheme=PaytreeChildPairCryptoScheme(),
         node_repo=node_repo,
         vendor_private_key_pem=settings.vendor_private_key_pem,
     )

--- a/src/nanomoni/api/vendor_api/routers/paytree_child_pair_payments.py
+++ b/src/nanomoni/api/vendor_api/routers/paytree_child_pair_payments.py
@@ -1,0 +1,115 @@
+"""PayTree child-pair payment API routes (Vendor)."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
+from prometheus_client import Counter, Gauge, Histogram
+
+from ....application.vendor.dtos import CloseChannelDTO
+from ....application.vendor.paytree_dtos import (
+    PaytreeChildPairPaymentResponseDTO,
+    ReceivePaytreeChildPairPaymentDTO,
+)
+from ....application.vendor.use_cases.paytree_child_pair_payment import (
+    PaytreeChildPairPaymentService,
+)
+from ..dependencies import get_paytree_child_pair_payment_service
+
+router = APIRouter(
+    prefix="/channels/paytree/child-pair", tags=["channels", "paytree-child-pair"]
+)
+
+
+PAYMENT_DURATION_BUCKETS = (
+    [round(0.5 * i, 1) for i in range(1, 21)]
+    + [float(x) for x in range(15, 55, 5)]
+    + [float("inf")]
+)
+
+paytree_child_pair_payment_requests_total = Counter(
+    "paytree_child_pair_payment_requests_total",
+    "Total PayTree child-pair payment requests processed",
+    ["status"],
+)
+
+paytree_child_pair_payment_request_duration_milliseconds = Histogram(
+    "paytree_child_pair_payment_request_duration_milliseconds",
+    "Wall time to process a PayTree child-pair payment request (ms)",
+    ["status"],
+    buckets=PAYMENT_DURATION_BUCKETS,
+)
+
+paytree_child_pair_payment_requests_inprogress = Gauge(
+    "paytree_child_pair_payment_requests_inprogress",
+    "Number of PayTree child-pair payment requests currently being processed",
+    multiprocess_mode="livesum",
+)
+
+
+@router.post(
+    "/{channel_id}/payments",
+    response_model=PaytreeChildPairPaymentResponseDTO,
+    status_code=status.HTTP_201_CREATED,
+)
+async def receive_paytree_child_pair_payment(
+    payment_data: ReceivePaytreeChildPairPaymentDTO,
+    channel_id: str = Path(..., description="Payment channel identifier"),
+    payment_service: PaytreeChildPairPaymentService = Depends(
+        get_paytree_child_pair_payment_service
+    ),
+) -> PaytreeChildPairPaymentResponseDTO:
+    start_time = time.perf_counter()
+    paytree_child_pair_payment_requests_inprogress.inc()
+    try:
+        result = await payment_service.receive_payment(channel_id, payment_data)
+        paytree_child_pair_payment_requests_total.labels(status="success").inc()
+        elapsed = (time.perf_counter() - start_time) * 1000
+        paytree_child_pair_payment_request_duration_milliseconds.labels(
+            status="success"
+        ).observe(elapsed)
+        return result
+    except ValueError as e:
+        paytree_child_pair_payment_requests_total.labels(status="client_error").inc()
+        elapsed = (time.perf_counter() - start_time) * 1000
+        paytree_child_pair_payment_request_duration_milliseconds.labels(
+            status="client_error"
+        ).observe(elapsed)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        paytree_child_pair_payment_requests_total.labels(status="server_error").inc()
+        elapsed = (time.perf_counter() - start_time) * 1000
+        paytree_child_pair_payment_request_duration_milliseconds.labels(
+            status="server_error"
+        ).observe(elapsed)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to process PayTree child-pair payment: {str(e)}",
+        )
+    finally:
+        paytree_child_pair_payment_requests_inprogress.dec()
+
+
+@router.post(
+    "/{channel_id}/closure-requests",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+async def settle_paytree_child_pair_channel(
+    payload: CloseChannelDTO,
+    channel_id: str = Path(..., description="Payment channel identifier"),
+    payment_service: PaytreeChildPairPaymentService = Depends(
+        get_paytree_child_pair_payment_service
+    ),
+) -> Response:
+    try:
+        await payment_service.settle_channel(payload)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to close PayTree child-pair channel: {str(e)}",
+        )

--- a/src/nanomoni/api/vendor_api/routers/paytree_child_pair_payments.py
+++ b/src/nanomoni/api/vendor_api/routers/paytree_child_pair_payments.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
@@ -16,16 +17,12 @@ from ....application.vendor.use_cases.paytree_child_pair_payment import (
     PaytreeChildPairPaymentService,
 )
 from ..dependencies import get_paytree_child_pair_payment_service
+from ..metrics import PAYMENT_DURATION_BUCKETS
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/channels/paytree/child-pair", tags=["channels", "paytree-child-pair"]
-)
-
-
-PAYMENT_DURATION_BUCKETS = (
-    [round(0.5 * i, 1) for i in range(1, 21)]
-    + [float(x) for x in range(15, 55, 5)]
-    + [float("inf")]
 )
 
 paytree_child_pair_payment_requests_total = Counter(
@@ -77,7 +74,8 @@ async def receive_paytree_child_pair_payment(
             status="client_error"
         ).observe(elapsed)
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
-    except Exception as e:
+    except Exception:
+        logger.exception("Failed to process PayTree child-pair payment")
         paytree_child_pair_payment_requests_total.labels(status="server_error").inc()
         elapsed = (time.perf_counter() - start_time) * 1000
         paytree_child_pair_payment_request_duration_milliseconds.labels(
@@ -85,7 +83,7 @@ async def receive_paytree_child_pair_payment(
         ).observe(elapsed)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to process PayTree child-pair payment: {str(e)}",
+            detail="Failed to process PayTree child-pair payment",
         )
     finally:
         paytree_child_pair_payment_requests_inprogress.dec()

--- a/src/nanomoni/application/issuer/paytree_dtos.py
+++ b/src/nanomoni/application/issuer/paytree_dtos.py
@@ -55,3 +55,14 @@ class PaytreeSettlementRequestDTO(BaseModel):
     leaf_b64: str
     siblings_b64: list[str]
     vendor_signature_b64: str
+
+
+class PaytreeChildPairSettlementRequestDTO(BaseModel):
+    """Settlement request for PayTree child-pair mode (vendor-signed frontier proof)."""
+
+    vendor_public_key_der_b64: str
+    k: int = Field(..., ge=1)
+    left_b64: str
+    right_b64: str
+    siblings_b64: list[str]
+    vendor_signature_b64: str

--- a/src/nanomoni/application/issuer/use_cases/paytree_channel.py
+++ b/src/nanomoni/application/issuer/use_cases/paytree_channel.py
@@ -16,11 +16,13 @@ from ....application.issuer.dtos import (
     GetPaymentChannelRequestDTO,
 )
 from ....application.issuer.paytree_dtos import (
+    PaytreeChildPairSettlementRequestDTO,
     PaytreeOpenChannelResponseDTO,
     PaytreePaymentChannelResponseDTO,
     PaytreeSettlementRequestDTO,
 )
 from ....application.shared.paytree_payloads import (
+    PaytreeChildPairSettlementPayload,
     PaytreeSettlementPayload,
 )
 from ....application.shared.serialization import payload_to_bytes
@@ -30,7 +32,10 @@ from ....crypto.certificates import (
     verify_signature_bytes,
     dto_to_canonical_json_bytes,
 )
-from ...shared.paytree_proof import verify_paytree_proof_standard
+from ...shared.paytree_proof import (
+    verify_paytree_child_pair_close,
+    verify_paytree_proof_standard,
+)
 from ....crypto.paytree import b64_to_bytes, compute_cumulative_owed_amount
 from ....domain.issuer.entities import Account, PaytreePaymentChannel
 from ....domain.issuer.repositories import AccountRepository, PaymentChannelRepository
@@ -268,6 +273,127 @@ class PaytreeChannelService:
             )
         except Exception as close_err:
             # Roll back both balance updates if closing persistence fails.
+            rollback_errors: list[Exception] = []
+            try:
+                await self.account_repo.update_balance(
+                    channel.vendor_public_key_der_b64, -cumulative_owed_amount
+                )
+            except Exception as e:
+                rollback_errors.append(e)
+            try:
+                await self.account_repo.update_balance(
+                    channel.client_public_key_der_b64, -remainder
+                )
+            except Exception as e:
+                rollback_errors.append(e)
+
+            if rollback_errors:
+                raise RuntimeError(
+                    "Failed to mark channel closed and failed to roll back balances"
+                ) from close_err
+            raise
+
+        return CloseChannelResponseDTO(
+            channel_id=channel_id,
+            client_balance=client_acc.balance,
+            vendor_balance=vendor_acc.balance,
+        )
+
+    async def settle_channel_child_pair(
+        self, channel_id: str, dto: PaytreeChildPairSettlementRequestDTO
+    ) -> CloseChannelResponseDTO:
+        """Settle a child-pair channel from a frontier proof (not a full leaf->root proof).
+
+        `channel.paytree_max_i` is reused as `max_k` for this mode: opening a
+        child-pair channel via `PaytreeOpenChannelRequestPayload` stores the
+        same root/unit_value/max fields regardless of which payment sub-protocol
+        the vendor and client use for per-payment verification.
+        """
+        channel = await self.channel_repo.get_by_channel_id(channel_id)
+        if not channel:
+            raise ValueError("Payment channel not found")
+        if channel.is_closed:
+            raise ValueError("Payment channel already closed")
+        if not isinstance(channel, PaytreePaymentChannel):
+            raise ValueError("Payment channel is not PayTree-enabled")
+
+        if dto.vendor_public_key_der_b64 != channel.vendor_public_key_der_b64:
+            raise ValueError("Mismatched vendor public key for channel")
+
+        if dto.k > channel.paytree_max_i:
+            raise ValueError("k exceeds PayTree max_k for this channel")
+
+        settlement_payload = PaytreeChildPairSettlementPayload(
+            channel_id=channel_id,
+            k=dto.k,
+            left_b64=dto.left_b64,
+            right_b64=dto.right_b64,
+            siblings_b64=dto.siblings_b64,
+        )
+        payload_bytes = payload_to_bytes(settlement_payload)
+        vendor_public_key = load_public_key_from_der_b64(
+            DERB64(channel.vendor_public_key_der_b64)
+        )
+        try:
+            verify_signature_bytes(
+                vendor_public_key, payload_bytes, dto.vendor_signature_b64
+            )
+        except InvalidSignature:
+            raise ValueError("Invalid vendor signature for PayTree settlement")
+
+        try:
+            _ = b64_to_bytes(channel.paytree_root_b64)
+        except Exception as e:
+            raise ValueError(f"Invalid PayTree root encoding: {e}") from e
+
+        if not verify_paytree_child_pair_close(
+            root_b64=channel.paytree_root_b64,
+            k=dto.k,
+            left_b64=dto.left_b64,
+            right_b64=dto.right_b64,
+            siblings_b64=dto.siblings_b64,
+        ):
+            raise ValueError("Invalid PayTree child-pair proof (root mismatch)")
+
+        cumulative_owed_amount = compute_cumulative_owed_amount(
+            i=dto.k, unit_value=channel.paytree_unit_value
+        )
+        if cumulative_owed_amount > channel.amount:
+            raise ValueError("Invalid owed amount")
+
+        vendor_acc = await self.account_repo.get_by_public_key(
+            channel.vendor_public_key_der_b64
+        )
+        if not vendor_acc:
+            vendor_acc = Account(
+                public_key_der_b64=channel.vendor_public_key_der_b64, balance=0
+            )
+            await self.account_repo.upsert(vendor_acc)
+
+        remainder = channel.amount - cumulative_owed_amount
+        vendor_acc = await self.account_repo.update_balance(
+            channel.vendor_public_key_der_b64, cumulative_owed_amount
+        )
+        try:
+            client_acc = await self.account_repo.update_balance(
+                channel.client_public_key_der_b64, remainder
+            )
+        except Exception:
+            await self.account_repo.update_balance(
+                channel.vendor_public_key_der_b64, -cumulative_owed_amount
+            )
+            raise
+
+        try:
+            await self.channel_repo.mark_closed(
+                channel_id,
+                close_payload_b64=None,
+                client_close_signature_b64=None,
+                amount=channel.amount,
+                balance=cumulative_owed_amount,
+                vendor_close_signature_b64=dto.vendor_signature_b64,
+            )
+        except Exception as close_err:
             rollback_errors: list[Exception] = []
             try:
                 await self.account_repo.update_balance(

--- a/src/nanomoni/application/shared/paytree_payloads.py
+++ b/src/nanomoni/application/shared/paytree_payloads.py
@@ -34,3 +34,21 @@ class PaytreeSettlementPayload(BaseModel):
     i: int = Field(..., ge=0)
     leaf_b64: str
     siblings_b64: list[str]
+
+
+class PaytreeChildPairSettlementPayload(BaseModel):
+    """Payload signed by the vendor when settling a PayTree child-pair channel.
+
+    Unlike the standard/first-opt settlement (full leaf->root proof), this
+    carries a frontier proof: the most recently paid node's children plus one
+    outer sibling per remaining level up to the root (see
+    `protocol.paytree_child_pair.verify_close_proof`).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    channel_id: str
+    k: int = Field(..., ge=1)
+    left_b64: str
+    right_b64: str
+    siblings_b64: list[str]

--- a/src/nanomoni/application/shared/paytree_proof.py
+++ b/src/nanomoni/application/shared/paytree_proof.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from nanomoni.crypto.paytree import b64_to_bytes
 from nanomoni.protocol import (
     subroot_index_standard,
+    verify_child_pair_close_proof,
+    verify_child_pair_payment,
     verify_proof_with_leaf_hash,
 )
 
@@ -61,3 +63,38 @@ def verify_paytree_proof_standard(
         subroot_index=subroot_index,
         depth=depth,
     )
+
+
+def verify_paytree_child_pair_payment(
+    *,
+    known_parent_b64: str,
+    left_b64: str,
+    right_b64: str,
+) -> bool:
+    """Verify a child-pair payment: H(left, right) == the already-known parent hash."""
+    try:
+        known_parent = b64_to_bytes(known_parent_b64)
+        left = b64_to_bytes(left_b64)
+        right = b64_to_bytes(right_b64)
+    except Exception:
+        return False
+    return verify_child_pair_payment(known_parent, left, right)
+
+
+def verify_paytree_child_pair_close(
+    *,
+    root_b64: str,
+    k: int,
+    left_b64: str,
+    right_b64: str,
+    siblings_b64: list[str],
+) -> bool:
+    """Verify a child-pair frontier close proof against the channel root."""
+    try:
+        root = b64_to_bytes(root_b64)
+        left = b64_to_bytes(left_b64)
+        right = b64_to_bytes(right_b64)
+        siblings = [b64_to_bytes(s) for s in siblings_b64]
+    except Exception:
+        return False
+    return verify_child_pair_close_proof(root, k, left, right, siblings)

--- a/src/nanomoni/application/shared/paytree_scheme.py
+++ b/src/nanomoni/application/shared/paytree_scheme.py
@@ -8,6 +8,7 @@ in ``crypto`` — keeping ``crypto`` a pure, dependency-free bottom layer.
 from __future__ import annotations
 
 from nanomoni.application.shared.paytree_proof import (
+    verify_paytree_child_pair_payment,
     verify_paytree_proof_first_opt,
     verify_paytree_proof_standard,
 )
@@ -102,3 +103,26 @@ class PaytreeFirstOptCryptoScheme:
             pos = get_sibling_position_at_level(leaf_index, level)
             updates[key_eytzinger(level, pos, depth)] = sib_b64
         return updates
+
+
+class PaytreeChildPairCryptoScheme:
+    """Stateless verifier for child-pair PayTree proofs (heap-indexed child reveal).
+
+    Unlike `PaytreeStdCryptoScheme`/`PaytreeFirstOptCryptoScheme`, verification
+    is against the already-known parent node hash (looked up by the caller
+    from the node store), not the channel commitment/root directly — the root
+    is only ever used to seed node 1 on the first payment.
+    """
+
+    def verify(self, known_parent_b64: str, left_b64: str, right_b64: str) -> bool:
+        return verify_paytree_child_pair_payment(
+            known_parent_b64=known_parent_b64,
+            left_b64=left_b64,
+            right_b64=right_b64,
+        )
+
+    def build_node_updates(
+        self, k: int, left_b64: str, right_b64: str
+    ) -> dict[str, str]:
+        """Build node_key → hash_b64 updates for the two newly revealed children of k."""
+        return {str(2 * k): left_b64, str(2 * k + 1): right_b64}

--- a/src/nanomoni/application/vendor/paytree_dtos.py
+++ b/src/nanomoni/application/vendor/paytree_dtos.py
@@ -35,3 +35,26 @@ class PaytreePaymentResponseDTO(CommonSerializersMixin, BaseModel):
     i: int
     cumulative_owed_amount: int
     created_at: datetime
+
+
+class ReceivePaytreeChildPairPaymentDTO(BaseModel):
+    """DTO for receiving a child-pair PayTree payment (heap-indexed child reveal).
+
+    Unlike first-opt, node keys here are just `str(k)` (no depth/level math),
+    so no `paytree_max_k` hint is needed to combine the channel+node read.
+    """
+
+    k: int = Field(
+        ..., ge=1, description="Eytzinger index of the parent node being expanded"
+    )
+    left_b64: str = Field(..., description="Base64-encoded left child hash (2k)")
+    right_b64: str = Field(..., description="Base64-encoded right child hash (2k+1)")
+
+
+class PaytreeChildPairPaymentResponseDTO(CommonSerializersMixin, BaseModel):
+    """DTO for returning child-pair PayTree payment acceptance data."""
+
+    channel_id: str
+    k: int
+    cumulative_owed_amount: int
+    created_at: datetime

--- a/src/nanomoni/application/vendor/use_cases/paytree_child_pair_payment.py
+++ b/src/nanomoni/application/vendor/use_cases/paytree_child_pair_payment.py
@@ -1,0 +1,325 @@
+"""Vendor use case: PayTree child-pair payments (heap-indexed child reveal).
+
+Per payment k, the client reveals the two children of node k (Eytzinger
+index); the vendor accepts iff H(left, right) equals the hash it already
+knows for node k (starting from the root at k=1), then learns nodes 2k and
+2k+1. Unlike first-opt, node keys are simply `str(k)` — no depth/level math
+is needed to address the sparse node store.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+from pydantic import ValidationError
+
+from ....application.issuer.dtos import GetPaymentChannelRequestDTO
+from ....application.issuer.paytree_dtos import PaytreeChildPairSettlementRequestDTO
+from ....application.shared.paytree_payloads import PaytreeChildPairSettlementPayload
+from ....application.shared.serialization import payload_to_bytes
+from ....crypto.certificates import load_private_key_from_pem, sign_bytes
+from ....protocol import build_child_pair_close_proof
+from ....crypto.paytree import b64_to_bytes, bytes_to_b64
+from ...shared.paytree_scheme import PaytreeChildPairCryptoScheme
+from ....domain.shared.crypto_proof import CryptoProof
+from ....domain.shared import IssuerClientFactory
+from ....domain.shared.proof_reference import PaymentScheme, ProofReference
+from ....domain.vendor.entities import PaymentChannel, PaymentState
+from ....domain.vendor.merkle_node_repository import MerkleNodeRepository
+from ....domain.vendor.payment_repository import PaymentRepository
+from ....infrastructure.http.http_client import HttpRequestError, HttpResponseError
+from ..dtos import CloseChannelDTO
+from ..paytree_dtos import (
+    PaytreeChildPairPaymentResponseDTO,
+    ReceivePaytreeChildPairPaymentDTO,
+)
+from .payment_validators import (
+    check_proof_reference_duplicate,
+    validate_proof_reference,
+)
+
+ROOT_KEY = "1"
+
+
+def _fingerprint(left_b64: str, right_b64: str) -> str:
+    return f"{left_b64}:{right_b64}"
+
+
+async def _fetch_and_validate_channel(
+    channel_id: str,
+    issuer_client_factory: IssuerClientFactory,
+    vendor_public_key_der_b64: str,
+) -> PaymentChannel:
+    """Fetch and validate channel from the issuer (child-pair endpoint)."""
+    try:
+        async with issuer_client_factory() as issuer_client:
+            dto = GetPaymentChannelRequestDTO(channel_id=channel_id)
+            issuer_channel = await issuer_client.get_paytree_child_pair_payment_channel(
+                dto
+            )
+
+            if issuer_channel.is_closed:
+                raise ValueError("Payment channel is closed")
+            if issuer_channel.vendor_public_key_der_b64 != vendor_public_key_der_b64:
+                raise ValueError("Payment channel is not for this vendor")
+
+            return PaymentChannel(
+                channel_id=issuer_channel.channel_id,
+                client_public_key_der_b64=issuer_channel.client_public_key_der_b64,
+                vendor_public_key_der_b64=issuer_channel.vendor_public_key_der_b64,
+                salt_b64=issuer_channel.salt_b64,
+                amount=issuer_channel.amount,
+                balance=issuer_channel.balance,
+                is_closed=issuer_channel.is_closed,
+                created_at=issuer_channel.created_at,
+                commitment=issuer_channel.paytree_root_b64,
+                scheme=PaymentScheme.PAYTREE_CHILD_PAIR,
+                max_steps=issuer_channel.paytree_max_i,
+                unit_value=issuer_channel.paytree_unit_value,
+            )
+
+    except HttpResponseError as e:
+        if e.response.status_code == 404:
+            raise ValueError("Payment channel not found on issuer")
+        raise ValueError(f"Failed to verify payment channel: {e}")
+    except HttpRequestError as e:
+        raise ValueError(f"Could not connect to issuer: {e}")
+    except ValidationError as e:
+        raise ValueError(f"Invalid payment channel data from issuer: {e}")
+
+
+class PaytreeChildPairPaymentService:
+    """Handles child-pair PayTree payments and settlement."""
+
+    def __init__(
+        self,
+        payment_repository: PaymentRepository,
+        issuer_client_factory: IssuerClientFactory,
+        vendor_public_key_der_b64: str,
+        crypto_scheme: PaytreeChildPairCryptoScheme,
+        node_repo: MerkleNodeRepository,
+        *,
+        vendor_private_key_pem: Optional[str] = None,
+    ):
+        self.payment_repository = payment_repository
+        self.issuer_client_factory = issuer_client_factory
+        self.vendor_public_key_der_b64 = vendor_public_key_der_b64
+        self.crypto_scheme = crypto_scheme
+        self.node_repo = node_repo
+        self.vendor_private_key_pem = vendor_private_key_pem
+
+    async def receive_payment(
+        self,
+        channel_id: str,
+        dto: ReceivePaytreeChildPairPaymentDTO,
+    ) -> PaytreeChildPairPaymentResponseDTO:
+        node_repo = self.node_repo
+        k_key = str(dto.k)
+
+        channel_json, nodes = await node_repo.get_channel_and_nodes(
+            channel_id, [ROOT_KEY, k_key]
+        )
+
+        if not channel_json:
+            payment_channel = await _fetch_and_validate_channel(
+                channel_id, self.issuer_client_factory, self.vendor_public_key_der_b64
+            )
+            if payment_channel.commitment:
+                await node_repo.merge_nodes(
+                    channel_id, {ROOT_KEY: payment_channel.commitment}
+                )
+                nodes[ROOT_KEY] = payment_channel.commitment
+        else:
+            payment_channel = PaymentChannel.model_validate_json(channel_json)
+            if not nodes.get(ROOT_KEY) and payment_channel.commitment:
+                await node_repo.merge_nodes(
+                    channel_id, {ROOT_KEY: payment_channel.commitment}
+                )
+                nodes[ROOT_KEY] = payment_channel.commitment
+
+        if payment_channel.is_closed:
+            raise ValueError("Payment channel is closed")
+
+        new_ref = ProofReference(value=dto.k)
+        prev_ref = (
+            ProofReference(value=payment_channel.last_proof_reference)
+            if payment_channel.last_proof_reference is not None
+            else None
+        )
+        cumulative_owed = new_ref.value * payment_channel.unit_value
+        fingerprint = _fingerprint(dto.left_b64, dto.right_b64)
+
+        if prev_ref is not None and new_ref.value <= prev_ref.value:
+            prev_state = await self.payment_repository.get_state(channel_id)
+            prev_fingerprint = prev_state.proof_fingerprint if prev_state else None
+            is_dup = check_proof_reference_duplicate(
+                new_ref=new_ref,
+                new_fingerprint=fingerprint,
+                prev_ref=prev_ref,
+                prev_fingerprint=prev_fingerprint,
+            )
+            if is_dup:
+                known_parent_b64 = nodes.get(k_key, "")
+                if not known_parent_b64 or not self.crypto_scheme.verify(
+                    known_parent_b64, dto.left_b64, dto.right_b64
+                ):
+                    raise ValueError("Invalid PayTree child-pair proof")
+                created_at = (
+                    prev_state.created_at if prev_state else datetime.now(timezone.utc)
+                )
+                return PaytreeChildPairPaymentResponseDTO(
+                    channel_id=channel_id,
+                    k=dto.k,
+                    cumulative_owed_amount=cumulative_owed,
+                    created_at=created_at,
+                )
+            raise ValueError(
+                f"PayTree k must be increasing. Got {dto.k}, channel has {prev_ref.value}"
+            )
+
+        validate_proof_reference(
+            new_ref=new_ref, prev_ref=prev_ref, max_steps=payment_channel.max_steps
+        )
+        if cumulative_owed > payment_channel.amount:
+            raise ValueError(
+                f"Cumulative owed {cumulative_owed} exceeds channel amount {payment_channel.amount}"
+            )
+
+        # The parent hash must come from a previously verified node (or the
+        # channel's own commitment, seeded at k=1) — never fall back to
+        # unverified client input.
+        known_parent_b64 = nodes.get(k_key, "")
+        if not known_parent_b64:
+            raise ValueError(
+                f"Unknown parent node for k={dto.k}; payments must reveal children "
+                "of an already-verified node, in increasing k order"
+            )
+
+        if not self.crypto_scheme.verify(known_parent_b64, dto.left_b64, dto.right_b64):
+            raise ValueError("Invalid PayTree child-pair proof (verification failed)")
+
+        node_updates = self.crypto_scheme.build_node_updates(
+            dto.k, dto.left_b64, dto.right_b64
+        )
+
+        created_at = datetime.now(timezone.utc)
+        new_state = PaymentState(
+            channel_id=channel_id,
+            proof_reference=dto.k,
+            cumulative_owed=cumulative_owed,
+            proof_fingerprint=fingerprint,
+            created_at=created_at,
+        )
+        store_proof = CryptoProof(
+            scheme=PaymentScheme.PAYTREE_CHILD_PAIR,
+            data={"left_b64": dto.left_b64, "right_b64": dto.right_b64},
+        )
+
+        payment_channel.last_proof_reference = dto.k
+        channel_json_updated = payment_channel.model_dump_json()
+        state_json = new_state.model_dump_json()
+        proof_json = json.dumps(
+            {"scheme": store_proof.scheme.value, **store_proof.data}
+        )
+
+        status, stored_ref = await node_repo.save_nodes_and_payment(
+            channel_id=channel_id,
+            node_updates=node_updates,
+            new_ref=dto.k,
+            channel_json=channel_json_updated,
+            state_json=state_json,
+            proof_json=proof_json,
+            is_closed=payment_channel.is_closed,
+            created_at_ts=payment_channel.created_at.timestamp(),
+        )
+
+        if status == 1:
+            return PaytreeChildPairPaymentResponseDTO(
+                channel_id=channel_id,
+                k=dto.k,
+                cumulative_owed_amount=cumulative_owed,
+                created_at=created_at,
+            )
+        if status == 0:
+            raise ValueError(
+                f"PayTree k must be increasing (race detected). Got {dto.k}, "
+                f"channel has {stored_ref}"
+            )
+        if status == 3:
+            raise ValueError("PayTree k exceeds max_k for this channel")
+        raise RuntimeError(f"Unexpected result from atomic save: status={status}")
+
+    async def settle_channel(self, dto: CloseChannelDTO) -> None:
+        channel_id = dto.channel_id
+        channel = await self.payment_repository.get_channel(channel_id)
+        if not channel:
+            raise ValueError("Payment channel not found")
+        if channel.is_closed:
+            return None
+
+        state = await self.payment_repository.get_state(channel_id)
+        if not state:
+            raise ValueError("No complete PayTree proof available for settlement")
+
+        k = state.proof_reference
+        cumulative_owed = k * channel.unit_value
+        if cumulative_owed > channel.amount:
+            raise ValueError("Invalid owed amount")
+
+        # Fetch every node needed to walk from k's children up to (but not
+        # including) the root: str(2k), str(2k+1), then str(sibling) at each
+        # level on the way up.
+        keys_needed = [str(2 * k), str(2 * k + 1)]
+        current = k
+        while current != 1:
+            keys_needed.append(str(current ^ 1))
+            current //= 2
+
+        nodes_b64 = await self.node_repo.get_nodes(channel_id, keys_needed)
+        try:
+            known: dict[int, bytes] = {
+                int(key): b64_to_bytes(value) for key, value in nodes_b64.items()
+            }
+            left, right, siblings = build_child_pair_close_proof(k, known)
+        except KeyError:
+            raise ValueError("No complete PayTree proof available for settlement")
+
+        left_b64 = bytes_to_b64(left)
+        right_b64 = bytes_to_b64(right)
+        siblings_b64 = [bytes_to_b64(s) for s in siblings]
+
+        settlement_payload = PaytreeChildPairSettlementPayload(
+            channel_id=channel_id,
+            k=k,
+            left_b64=left_b64,
+            right_b64=right_b64,
+            siblings_b64=siblings_b64,
+        )
+        payload_bytes = payload_to_bytes(settlement_payload)
+
+        if not self.vendor_private_key_pem:
+            raise ValueError("Vendor private key is not configured")
+        vendor_private_key = load_private_key_from_pem(self.vendor_private_key_pem)
+        vendor_signature_b64 = sign_bytes(vendor_private_key, payload_bytes)
+
+        request_dto = PaytreeChildPairSettlementRequestDTO(
+            vendor_public_key_der_b64=channel.vendor_public_key_der_b64,
+            k=k,
+            left_b64=left_b64,
+            right_b64=right_b64,
+            siblings_b64=siblings_b64,
+            vendor_signature_b64=vendor_signature_b64,
+        )
+
+        async with self.issuer_client_factory() as issuer_client:
+            await issuer_client.settle_paytree_child_pair_payment_channel(
+                channel_id, request_dto
+            )
+
+        await self.payment_repository.mark_closed(
+            channel_id=channel_id,
+            amount=channel.amount,
+            balance=cumulative_owed,
+        )

--- a/src/nanomoni/application/vendor/use_cases/paytree_child_pair_payment.py
+++ b/src/nanomoni/application/vendor/use_cases/paytree_child_pair_payment.py
@@ -9,7 +9,6 @@ is needed to address the sparse node store.
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -118,11 +117,11 @@ class PaytreeChildPairPaymentService:
         node_repo = self.node_repo
         k_key = str(dto.k)
 
-        channel_json, nodes = await node_repo.get_channel_and_nodes(
+        payment_channel, nodes = await node_repo.get_channel_and_nodes(
             channel_id, [ROOT_KEY, k_key]
         )
 
-        if not channel_json:
+        if payment_channel is None:
             payment_channel = await _fetch_and_validate_channel(
                 channel_id, self.issuer_client_factory, self.vendor_public_key_der_b64
             )
@@ -132,7 +131,6 @@ class PaytreeChildPairPaymentService:
                 )
                 nodes[ROOT_KEY] = payment_channel.commitment
         else:
-            payment_channel = PaymentChannel.model_validate_json(channel_json)
             if not nodes.get(ROOT_KEY) and payment_channel.commitment:
                 await node_repo.merge_nodes(
                     channel_id, {ROOT_KEY: payment_channel.commitment}
@@ -218,21 +216,14 @@ class PaytreeChildPairPaymentService:
         )
 
         payment_channel.last_proof_reference = dto.k
-        channel_json_updated = payment_channel.model_dump_json()
-        state_json = new_state.model_dump_json()
-        proof_json = json.dumps(
-            {"scheme": store_proof.scheme.value, **store_proof.data}
-        )
 
         status, stored_ref = await node_repo.save_nodes_and_payment(
             channel_id=channel_id,
             node_updates=node_updates,
             new_ref=dto.k,
-            channel_json=channel_json_updated,
-            state_json=state_json,
-            proof_json=proof_json,
-            is_closed=payment_channel.is_closed,
-            created_at_ts=payment_channel.created_at.timestamp(),
+            channel=payment_channel,
+            state=new_state,
+            proof=store_proof,
         )
 
         if status == 1:

--- a/src/nanomoni/application/vendor/use_cases/paytree_first_opt_payment.py
+++ b/src/nanomoni/application/vendor/use_cases/paytree_first_opt_payment.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -116,11 +115,11 @@ class PaytreeFirstOptPaymentService:
             dto.i, len(dto.siblings_b64), prefetch_depth
         )
 
-        channel_json, nodes = await node_repo.get_channel_and_nodes(
+        payment_channel, nodes = await node_repo.get_channel_and_nodes(
             channel_id, [prefetch_root_key, prefetch_subroot_index]
         )
 
-        if not channel_json:
+        if payment_channel is None:
             payment_channel = await _fetch_and_validate_channel(
                 channel_id, self.issuer_client_factory, self.vendor_public_key_der_b64
             )
@@ -129,7 +128,6 @@ class PaytreeFirstOptPaymentService:
                     channel_id, {prefetch_root_key: payment_channel.commitment}
                 )
         else:
-            payment_channel = PaymentChannel.model_validate_json(channel_json)
             root_b64 = nodes.get(prefetch_root_key) or ""
             if not root_b64 and payment_channel.commitment:
                 await node_repo.merge_nodes(
@@ -235,24 +233,18 @@ class PaytreeFirstOptPaymentService:
         )
 
         payment_channel.last_proof_reference = dto.i
-        channel_json_updated = payment_channel.model_dump_json()
-        state_json = new_state.model_dump_json()
-        proof_json = json.dumps(
-            {"scheme": store_proof.scheme.value, **store_proof.data}
-        )
 
         # The atomic monotonic CAS lives inside save_nodes_and_payment, so a
         # concurrent request that advanced the reference cannot be overwritten
-        # here (unlike the previous unconditional SET).
+        # here (unlike the previous unconditional SET). Serialization of
+        # channel/state/proof happens inside the repository call itself.
         status, stored_ref = await node_repo.save_nodes_and_payment(
             channel_id=channel_id,
             node_updates=node_updates,
             new_ref=dto.i,
-            channel_json=channel_json_updated,
-            state_json=state_json,
-            proof_json=proof_json,
-            is_closed=payment_channel.is_closed,
-            created_at_ts=payment_channel.created_at.timestamp(),
+            channel=payment_channel,
+            state=new_state,
+            proof=store_proof,
         )
 
         if status == 1:

--- a/src/nanomoni/client/common.py
+++ b/src/nanomoni/client/common.py
@@ -18,13 +18,23 @@ ClientMode = Literal[
     "payword",
     "paytree",
     "paytree_first_opt",
+    "paytree_child_pair",
 ]
+
+_VALID_MODES = {
+    "signature",
+    "payword",
+    "paytree",
+    "paytree_first_opt",
+    "paytree_child_pair",
+}
 
 
 def validate_mode(mode: str) -> ClientMode:
-    if mode not in {"signature", "payword", "paytree", "paytree_first_opt"}:
+    if mode not in _VALID_MODES:
         raise RuntimeError(
-            "client_payment_mode must be 'signature', 'payword', 'paytree', or 'paytree_first_opt'"
+            "client_payment_mode must be one of: "
+            "'signature', 'payword', 'paytree', 'paytree_first_opt', 'paytree_child_pair'"
         )
     return mode  # type: ignore[return-value]
 
@@ -43,6 +53,9 @@ async def open_channel_for_mode(
     elif mode == "paytree_first_opt":
         paytree_channel = await issuer.open_paytree_first_opt_payment_channel(open_dto)
         return paytree_channel.channel_id
+    elif mode == "paytree_child_pair":
+        paytree_channel = await issuer.open_paytree_child_pair_payment_channel(open_dto)
+        return paytree_channel.channel_id
     else:
         sig_channel = await issuer.open_payment_channel(open_dto)
         return sig_channel.channel_id
@@ -60,6 +73,8 @@ async def request_settle_for_mode(
         await vendor.request_settle_channel_paytree_std(close_dto)
     elif mode == "paytree_first_opt":
         await vendor.request_settle_channel_paytree_first_opt(close_dto)
+    elif mode == "paytree_child_pair":
+        await vendor.request_settle_channel_paytree_child_pair(close_dto)
     else:
         await vendor.request_settle_channel(close_dto)
 
@@ -80,6 +95,9 @@ async def wait_until_closed(
         elif mode == "paytree_first_opt":
             if (await issuer.get_paytree_first_opt_payment_channel(get_dto)).is_closed:
                 break
+        elif mode == "paytree_child_pair":
+            if (await issuer.get_paytree_child_pair_payment_channel(get_dto)).is_closed:
+                break
         else:
             if (await issuer.get_payment_channel(get_dto)).is_closed:
                 break
@@ -98,7 +116,7 @@ def compute_final_cumulative_owed_amount(
 
     if mode == "signature":
         return payments[-1]
-    elif mode in {"payword", "paytree", "paytree_first_opt"}:
+    elif mode in {"payword", "paytree", "paytree_first_opt", "paytree_child_pair"}:
         if unit_value is None:
             raise ValueError(f"unit_value is required for {mode} mode")
         return payments[-1] * unit_value

--- a/src/nanomoni/client/paytree.py
+++ b/src/nanomoni/client/paytree.py
@@ -12,6 +12,7 @@ from nanomoni.application.issuer.dtos import OpenChannelRequestDTO
 from nanomoni.application.vendor.paytree_dtos import (
     ReceivePaytreeStdPaymentDTO,
     ReceivePaytreeFirstOptPaymentDTO,
+    ReceivePaytreeChildPairPaymentDTO,
 )
 from nanomoni.crypto.paytree import Paytree
 from nanomoni.crypto.certificates import (
@@ -39,6 +40,28 @@ def init_commitment(
     paytree = Paytree.create(max_i=paytree_max_i)
     paytree_root_b64 = paytree.commitment_root_b64
     return paytree, paytree_root_b64, paytree_unit_value, paytree_max_i
+
+
+def init_commitment_child_pair(
+    settings: Settings,
+    payment_count: int,
+) -> tuple[Paytree, str, int, int]:
+    """Initialize a child-pair PayTree commitment.
+
+    Returns (paytree, root_b64, unit_value, max_k) — unlike `init_commitment`,
+    the fourth value is the tree's `max_k` (number of internal nodes), which
+    is what gets sent as the channel's `paytree_max_i` field: child-pair
+    payments are indexed by Eytzinger node index k, not by leaf index.
+    """
+    paytree_unit_value = settings.client_paytree_unit_value
+    paytree_max_i = (
+        settings.client_paytree_max_i
+        if settings.client_paytree_max_i is not None
+        else payment_count
+    )
+    paytree = Paytree.create(max_i=paytree_max_i)
+    paytree_root_b64 = paytree.commitment_root_b64
+    return paytree, paytree_root_b64, paytree_unit_value, paytree.max_k
 
 
 def build_open_payload(
@@ -162,5 +185,37 @@ async def send_first_opt_payments(
                 leaf_b64=leaf_b64,
                 siblings_b64=siblings_b64,
                 paytree_max_i=paytree.max_i,
+            ),
+        )
+
+
+async def send_child_pair_payments(
+    vendor: VendorClientAsync,
+    channel_id: str,
+    paytree: Paytree,
+    payments: list[int],
+    inter_payment_delay: float = 0.0,
+) -> None:
+    """Send child-pair PayTree payments to the vendor.
+
+    ``payments`` are Eytzinger node indexes k (must be sent in increasing
+    order, each revealing the two children of node k).
+    """
+    start = perf_counter()
+    for n, k in enumerate(payments):
+        if inter_payment_delay > 0:
+            target = start + n * inter_payment_delay
+            now = perf_counter()
+            if target > now:
+                await sleep(target - now)
+            elif now - target > inter_payment_delay:
+                start = now - n * inter_payment_delay
+        k_val, left_b64, right_b64 = paytree.payment_proof_child_pair(k)
+        await vendor.send_paytree_child_pair_payment(
+            channel_id,
+            ReceivePaytreeChildPairPaymentDTO(
+                k=k_val,
+                left_b64=left_b64,
+                right_b64=right_b64,
             ),
         )

--- a/src/nanomoni/client_pay_chan.py
+++ b/src/nanomoni/client_pay_chan.py
@@ -94,6 +94,16 @@ async def run_client_flow() -> None:
             final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
                 client_mode, payments, paytree_unit_value
             )
+        elif client_mode == "paytree_child_pair":
+            paytree_obj, paytree_root_b64, paytree_unit_value, paytree_max_i = (
+                paytree.init_commitment_child_pair(settings, payment_count)
+            )
+            # Child-pair payments are indexed by Eytzinger node k (1..max_k),
+            # not by leaf index; clip the requested payment count to max_k.
+            payments = list(range(1, min(payment_count, paytree_obj.max_k) + 1))
+            final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
+                client_mode, payments, paytree_unit_value
+            )
         else:
             final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
                 client_mode, payments
@@ -121,6 +131,16 @@ async def run_client_flow() -> None:
                 paytree_max_i,
             )
         elif client_mode == "paytree_first_opt":
+            open_dto = paytree.build_open_channel_request(
+                client_private_key,
+                settings.client_public_key_der_b64,
+                vendor_pk.public_key_der_b64,
+                channel_amount,
+                paytree_root_b64,
+                paytree_unit_value,
+                paytree_max_i,
+            )
+        elif client_mode == "paytree_child_pair":
             open_dto = paytree.build_open_channel_request(
                 client_private_key,
                 settings.client_public_key_der_b64,
@@ -189,6 +209,17 @@ async def run_client_flow() -> None:
                 raise RuntimeError(PAYTREE_NOT_INITIALIZED)
             paytree_for_payments = paytree_obj
             await paytree.send_first_opt_payments(
+                vendor,
+                channel_id,
+                paytree_for_payments,
+                payments,
+                inter_payment_delay=delay,
+            )
+        elif client_mode == "paytree_child_pair":
+            if paytree_obj is None:
+                raise RuntimeError(PAYTREE_NOT_INITIALIZED)
+            paytree_for_payments = paytree_obj
+            await paytree.send_child_pair_payments(
                 vendor,
                 channel_id,
                 paytree_for_payments,

--- a/src/nanomoni/crypto/paytree.py
+++ b/src/nanomoni/crypto/paytree.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .merkle_index import (
+    compute_tree_depth,
     get_sibling_position_at_level,
     is_left_child,
     key,
@@ -25,6 +26,7 @@ from .merkle_tree import (
     proof_indexes_first_opt,
     verify_proof_to_known_node,
 )
+from .paytree_child_pair import children_of_k, max_k_for_depth, node_hash_at_k
 
 
 def b64_to_bytes(data_b64: str) -> bytes:
@@ -209,6 +211,30 @@ class Paytree:
         leaf_b64 = bytes_to_b64(leaf_hash)
         siblings_b64 = [bytes_to_b64(s) for s in siblings]
         return i, leaf_b64, siblings_b64
+
+    @property
+    def depth(self) -> int:
+        """Tree depth (number of sibling levels from a leaf to the root)."""
+        return compute_tree_depth(self.max_i)
+
+    @property
+    def max_k(self) -> int:
+        """Largest child-pair payment index (number of internal nodes in the tree)."""
+        return max_k_for_depth(self.depth)
+
+    def payment_proof_child_pair(self, k: int) -> tuple[int, str, str]:
+        """Generate the child-pair payment proof for index k: (k, left_b64, right_b64).
+
+        k is the Eytzinger index of the internal node being expanded; the
+        proof reveals its two children (2k, 2k+1).
+        """
+        if k < 1 or k > self.max_k:
+            raise ValueError(f"Index k={k} out of range [1, {self.max_k}]")
+
+        left_k, right_k = children_of_k(k)
+        left = node_hash_at_k(self._tree_levels, self.depth, left_k)
+        right = node_hash_at_k(self._tree_levels, self.depth, right_k)
+        return k, bytes_to_b64(left), bytes_to_b64(right)
 
 
 def compute_cumulative_owed_amount(*, i: int, unit_value: int) -> int:

--- a/src/nanomoni/crypto/paytree_child_pair.py
+++ b/src/nanomoni/crypto/paytree_child_pair.py
@@ -1,0 +1,51 @@
+"""PayTree child-pair protocol: heap-indexed child revelation per payment.
+
+Nodes are addressed by their 1-based Eytzinger index k (root = 1; children of
+k are 2k and 2k+1) — the same numbering `merkle_index.eytzinger_index`
+already produces for (level, position). Payment k reveals the two children of
+node k; the vendor accepts iff H(left, right) == the hash it already knows
+for node k, then learns nodes 2k and 2k+1.
+
+This module only holds tree-shape helpers (children/siblings by index and
+looking up a node's hash from a built tree). Verification and close-proof
+composition compose these with `merkle_tree.hash_bytes` /
+`verify_proof_to_known_node` in the protocol layer.
+"""
+
+from __future__ import annotations
+
+from .merkle_index import level_position_from_eytzinger
+
+
+def max_k_for_depth(depth: int) -> int:
+    """Largest payment index for a tree of the given depth (number of internal nodes).
+
+    A tree with 2**depth leaves has 2**depth - 1 internal nodes (Eytzinger
+    indexes 1..2**depth - 1); each is revealed by exactly one payment.
+    """
+    if depth < 0:
+        raise ValueError("depth must be >= 0")
+    return (1 << depth) - 1
+
+
+def children_of_k(k: int) -> tuple[int, int]:
+    """Eytzinger indexes of the two children of node k: (2k, 2k+1)."""
+    if k < 1:
+        raise ValueError("k must be >= 1")
+    return 2 * k, 2 * k + 1
+
+
+def sibling_of_k(k: int) -> int:
+    """Eytzinger index of k's sibling (the other child of k's parent): k XOR 1.
+
+    Undefined for the root (k=1), which has no sibling.
+    """
+    if k <= 1:
+        raise ValueError("root (k=1) has no sibling")
+    return k ^ 1
+
+
+def node_hash_at_k(tree_levels: list[list[bytes]], depth: int, k: int) -> bytes:
+    """Hash of the node at Eytzinger index k, read from a built tree (tree_levels[0] = leaves)."""
+    level, position = level_position_from_eytzinger(k, depth)
+    return tree_levels[level][position]

--- a/src/nanomoni/domain/shared/issuer_client_protocol.py
+++ b/src/nanomoni/domain/shared/issuer_client_protocol.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
         PaywordSettlementRequestDTO,
     )
     from ...application.issuer.paytree_dtos import (
+        PaytreeChildPairSettlementRequestDTO,
         PaytreeOpenChannelResponseDTO,
         PaytreePaymentChannelResponseDTO,
         PaytreeSettlementRequestDTO,
@@ -187,6 +188,22 @@ class IssuerClientProtocol(Protocol):
         self,
         channel_id: str,
         dto: "PaytreeSettlementRequestDTO",
+    ) -> "CloseChannelResponseDTO": ...
+
+    # PayTree Child-Pair Payment Channels
+
+    async def open_paytree_child_pair_payment_channel(
+        self, dto: "OpenChannelRequestDTO"
+    ) -> "PaytreeOpenChannelResponseDTO": ...
+
+    async def get_paytree_child_pair_payment_channel(
+        self, dto: "GetPaymentChannelRequestDTO"
+    ) -> "PaytreePaymentChannelResponseDTO": ...
+
+    async def settle_paytree_child_pair_payment_channel(
+        self,
+        channel_id: str,
+        dto: "PaytreeChildPairSettlementRequestDTO",
     ) -> "CloseChannelResponseDTO": ...
 
     # Context Manager Support

--- a/src/nanomoni/domain/shared/proof_reference.py
+++ b/src/nanomoni/domain/shared/proof_reference.py
@@ -19,3 +19,4 @@ class ProofReference:
 class PaymentScheme(str, Enum):
     PAYWORD = "payword"
     PAYTREE = "paytree"
+    PAYTREE_CHILD_PAIR = "paytree_child_pair"

--- a/src/nanomoni/domain/vendor/merkle_node_repository.py
+++ b/src/nanomoni/domain/vendor/merkle_node_repository.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Optional, Protocol
 
+from ..shared.crypto_proof import CryptoProof
+from .entities import PaymentChannel, PaymentState
+
 
 class MerkleNodeRepository(Protocol):
     async def get_nodes(self, channel_id: str, keys: list[str]) -> dict[str, str]: ...
@@ -12,14 +15,9 @@ class MerkleNodeRepository(Protocol):
         self,
         channel_id: str,
         read_keys: list[str],
-    ) -> tuple[Optional[str], dict[str, str]]: ...
-
-    async def get_nodes_and_merge(
-        self,
-        channel_id: str,
-        read_keys: list[str],
-        updates: dict[str, str],
-    ) -> dict[str, str]: ...
+    ) -> tuple[Optional[PaymentChannel], dict[str, str]]:
+        """Read the channel (deserialized) and a batch of node keys in one round trip."""
+        ...
 
     async def merge_nodes(self, channel_id: str, updates: dict[str, str]) -> None: ...
 
@@ -28,13 +26,15 @@ class MerkleNodeRepository(Protocol):
         channel_id: str,
         node_updates: dict[str, str],
         new_ref: int,
-        channel_json: str,
-        state_json: str,
-        proof_json: str,
-        is_closed: bool,
-        created_at_ts: float,
+        channel: PaymentChannel,
+        state: PaymentState,
+        proof: CryptoProof,
     ) -> tuple[int, Optional[int]]:
         """Atomically save merkle nodes + channel/state/proof with a monotonic CAS.
+
+        Serializes ``channel``/``state``/``proof`` internally (mirroring
+        ``PaymentRepositoryImpl.save_payment``), so this cost is consistently
+        attributed to the repository layer rather than the calling use case.
 
         Returns (status, stored_ref):
           1 = success (stored_ref = new_ref)

--- a/src/nanomoni/envs/client_env.py
+++ b/src/nanomoni/envs/client_env.py
@@ -21,6 +21,7 @@ class Settings(BaseModel):
     client_payment_count: int = 1
     client_channel_amount: int = 1
     # signature | payword | paytree | paytree_first_opt (paytree with pruned proofs, opt type 1)
+    # | paytree_child_pair (heap-indexed child reveal per payment)
     client_payment_mode: str = "signature"
     client_payword_unit_value: int = 1
     client_payword_max_k: Optional[int] = None

--- a/src/nanomoni/infrastructure/issuer/issuer_client.py
+++ b/src/nanomoni/infrastructure/issuer/issuer_client.py
@@ -22,6 +22,7 @@ from ...application.issuer.payword_dtos import (
     PaywordSettlementRequestDTO,
 )
 from ...application.issuer.paytree_dtos import (
+    PaytreeChildPairSettlementRequestDTO,
     PaytreeOpenChannelResponseDTO,
     PaytreePaymentChannelResponseDTO,
     PaytreeSettlementRequestDTO,
@@ -219,6 +220,30 @@ class AsyncIssuerClient:
         dto: PaytreeSettlementRequestDTO,
     ) -> CloseChannelResponseDTO:
         path = f"/issuer/channels/paytree/first-opt/{channel_id}/settlements"
+        resp = await self._http.post(path, json=dto.model_dump())
+        return CloseChannelResponseDTO.model_validate(resp.json())
+
+    async def open_paytree_child_pair_payment_channel(
+        self, dto: OpenChannelRequestDTO
+    ) -> PaytreeOpenChannelResponseDTO:
+        resp = await self._http.post(
+            "/issuer/channels/paytree/child-pair", json=dto.model_dump()
+        )
+        return PaytreeOpenChannelResponseDTO.model_validate(resp.json())
+
+    async def get_paytree_child_pair_payment_channel(
+        self, dto: GetPaymentChannelRequestDTO
+    ) -> PaytreePaymentChannelResponseDTO:
+        path = f"/issuer/channels/paytree/child-pair/{dto.channel_id}"
+        resp = await self._http.get(path)
+        return PaytreePaymentChannelResponseDTO.model_validate(resp.json())
+
+    async def settle_paytree_child_pair_payment_channel(
+        self,
+        channel_id: str,
+        dto: PaytreeChildPairSettlementRequestDTO,
+    ) -> CloseChannelResponseDTO:
+        path = f"/issuer/channels/paytree/child-pair/{channel_id}/settlements"
         resp = await self._http.post(path, json=dto.model_dump())
         return CloseChannelResponseDTO.model_validate(resp.json())
 

--- a/src/nanomoni/infrastructure/scripts.py
+++ b/src/nanomoni/infrastructure/scripts.py
@@ -65,7 +65,9 @@ _SAVE_CHANNEL_AND_INITIAL_STATE_SCRIPT = """
     redis.call('ZADD', 'payment_channels:all', created_ts, channel_id)
     redis.call('ZADD', 'payment_channels:open', created_ts, channel_id)
 
-    return {1, state_json}
+    -- Caller already has state_json (it built it); echoing it back would
+    -- just make the caller re-parse what it wrote.
+    return {1, ''}
 """
 
 VENDOR_SCRIPTS["save_channel_and_initial_payment"] = (
@@ -141,13 +143,23 @@ _SAVE_CHANNEL_AND_INITIAL_PAYMENT_UNIFIED_SCRIPT = """
     redis.call('ZADD', 'payment_channels:all', created_ts, channel_id)
     redis.call('ZADD', 'payment_channels:open', created_ts, channel_id)
 
-    return {1, state_json}
+    -- Caller already has state_json (it built it); echoing it back would
+    -- just make the caller re-parse what it wrote.
+    return {1, ''}
 """
 
 # save_payment_with_nodes: first-opt PayTree atomic save (nodes + channel + state + proof).
 # Performs the same monotonic CAS as save_payment (against the *stored* channel's
 # last_proof_reference / max_steps) so concurrent first-opt payments cannot move the
 # reference backwards or exceed capacity. Nothing is written unless the CAS passes.
+#
+# is_closed is accepted only to register a brand-new channel in the correct
+# open/closed index on its first write; on every later write it is always
+# whatever the stored channel already has (closing a channel goes through
+# mark_closed()/update(), a separate write path -- see
+# payment_channel_repository_base_impl.py), so there is no open<->closed
+# transition to detect here.
+#
 # KEYS[1] = merkle_node_index:{id}, KEYS[2] = payment_channel:{id},
 # KEYS[3] = payment_state:{id}, KEYS[4] = crypto_proof:{id},
 # KEYS[5] = payment_channels:open, KEYS[6] = payment_channels:closed
@@ -180,11 +192,11 @@ _SAVE_PAYMENT_WITH_NODES_SCRIPT = """
     -- to the channel_json being written (sourced from the issuer).
     local max_steps = nil
     local prev = -1
-    local old_is_closed = nil
+    local is_new_channel = true
     local existing = redis.call('GET', channel_key)
     if existing and existing ~= '' then
+        is_new_channel = false
         local ch = cjson.decode(existing)
-        old_is_closed = ch.is_closed
         max_steps = tonumber(ch.max_steps)
         local last_ref = ch.last_proof_reference
         if last_ref ~= nil and last_ref ~= cjson.null then
@@ -217,7 +229,7 @@ _SAVE_PAYMENT_WITH_NODES_SCRIPT = """
     redis.call('SET', state_key, state_json)
     redis.call('SET', proof_key, proof_json)
 
-    if old_is_closed == nil then
+    if is_new_channel then
         -- Brand-new channel in the vendor store: register it in the indexes so
         -- get_all()/listing and index-based cleanup can see it.
         redis.call('ZADD', 'payment_channels:all', created_ts, channel_id)
@@ -226,36 +238,9 @@ _SAVE_PAYMENT_WITH_NODES_SCRIPT = """
         else
             redis.call('ZADD', open_key, created_ts, channel_id)
         end
-    elseif old_is_closed ~= new_is_closed then
-        if new_is_closed then
-            redis.call('ZREM', open_key, channel_id)
-            redis.call('ZADD', closed_key, created_ts, channel_id)
-        else
-            redis.call('ZREM', closed_key, channel_id)
-            redis.call('ZADD', open_key, created_ts, channel_id)
-        end
     end
 
     return {1, tostring(new_ref)}
-"""
-
-# Merkle node read+merge: MGET two nodes then MSET+ZADD updates atomically.
-# KEYS[1] = merkle_node_index:{id}, KEYS[2] = read key 1, KEYS[3] = read key 2
-# ARGV[1] = channel_id, ARGV[2] = num_updates, ARGV[3+] = suffix, val pairs
-_MERKLE_GET_NODES_AND_MERGE_SCRIPT = """
-    local index_key = KEYS[1]
-    local read1 = redis.call('GET', KEYS[2])
-    local read2 = redis.call('GET', KEYS[3])
-    local channel_id = ARGV[1]
-    local n = tonumber(ARGV[2]) or 0
-    local prefix = "merkle_node:" .. channel_id .. ":"
-    for i = 1, n do
-        local suffix = ARGV[2 + (i-1)*2 + 1]
-        local val = ARGV[2 + (i-1)*2 + 2]
-        redis.call('SET', prefix .. suffix, val)
-        redis.call('ZADD', index_key, 0, suffix)
-    end
-    return {read1 or '', read2 or ''}
 """
 
 # Merkle node merge only: MSET + ZADD in one shot.
@@ -280,7 +265,6 @@ VENDOR_SCRIPTS.update(
         "save_payment": _SAVE_PAYMENT_SCRIPT,
         "save_channel_and_initial_payment_unified": _SAVE_CHANNEL_AND_INITIAL_PAYMENT_UNIFIED_SCRIPT,
         "save_payment_with_nodes": _SAVE_PAYMENT_WITH_NODES_SCRIPT,
-        "merkle_get_nodes_and_merge": _MERKLE_GET_NODES_AND_MERGE_SCRIPT,
         "merkle_merge_nodes": _MERKLE_MERGE_NODES_SCRIPT,
     }
 )

--- a/src/nanomoni/infrastructure/vendor/merkle_node_repository_impl.py
+++ b/src/nanomoni/infrastructure/vendor/merkle_node_repository_impl.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from typing import Optional
 
+from ...domain.shared.crypto_proof import CryptoProof
+from ...domain.vendor.entities import PaymentChannel, PaymentState
 from ...domain.vendor.merkle_node_repository import MerkleNodeRepository
 from ...infrastructure.storage import KeyValueStore
 
@@ -41,7 +44,7 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
         self,
         channel_id: str,
         read_keys: list[str],
-    ) -> tuple[str | None, dict[str, str]]:
+    ) -> tuple[Optional[PaymentChannel], dict[str, str]]:
         channel_key = f"payment_channel:{channel_id}"
         read_redis_keys = [_node_key(channel_id, k) for k in read_keys]
         if len(read_redis_keys) < 2:
@@ -50,14 +53,16 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
             [channel_key, read_redis_keys[0], read_redis_keys[1]]
         )
         channel_raw = (values[0] or "").strip() if values else ""
-        channel_json = channel_raw if channel_raw else None
+        channel = (
+            PaymentChannel.model_validate_json(channel_raw) if channel_raw else None
+        )
         out: dict[str, str] = {}
         for i, k in enumerate(read_keys[:2]):
             val = (
                 (values[i + 1] or "").strip() if values and i + 1 < len(values) else ""
             )
             out[k] = val
-        return channel_json, out
+        return channel, out
 
     async def get_nodes(self, channel_id: str, node_keys: list[str]) -> dict[str, str]:
         if not node_keys:
@@ -65,28 +70,6 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
         keys = [_node_key(channel_id, k) for k in node_keys]
         values = await self._store.mget(keys)
         return {node_keys[i]: v for i, v in enumerate(values) if v is not None}
-
-    async def get_nodes_and_merge(
-        self,
-        channel_id: str,
-        read_keys: list[str],
-        updates: dict[str, str],
-    ) -> dict[str, str]:
-        index = _index_key(channel_id)
-        read_redis_keys = [_node_key(channel_id, k) for k in read_keys]
-        if len(read_redis_keys) < 2:
-            read_redis_keys.extend([read_redis_keys[0]] * (2 - len(read_redis_keys)))
-        keys = [index, read_redis_keys[0], read_redis_keys[1]]
-        args = [channel_id, str(len(updates))]
-        for node_key, hash_b64 in updates.items():
-            args.extend([node_key, hash_b64])
-        result = await self._store.run_script(
-            "merkle_get_nodes_and_merge", keys=keys, args=args
-        )
-        out: dict[str, str] = {}
-        for i, k in enumerate(read_keys[:2]):
-            out[k] = (result[i] or "") if result and i < len(result) else ""
-        return out
 
     async def merge_nodes(self, channel_id: str, updates: dict[str, str]) -> None:
         if not updates:
@@ -103,11 +86,9 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
         channel_id: str,
         node_updates: dict[str, str],
         new_ref: int,
-        channel_json: str,
-        state_json: str,
-        proof_json: str,
-        is_closed: bool,
-        created_at_ts: float,
+        channel: PaymentChannel,
+        state: PaymentState,
+        proof: CryptoProof,
     ) -> tuple[int, Optional[int]]:
         index_key = _index_key(channel_id)
         channel_key = f"payment_channel:{channel_id}"
@@ -121,6 +102,9 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
             "payment_channels:open",
             "payment_channels:closed",
         ]
+        channel_json = channel.model_dump_json()
+        state_json = state.model_dump_json()
+        proof_json = json.dumps({"scheme": proof.scheme.value, **proof.data})
         n = len(node_updates)
         args = [channel_id, str(n)]
         for node_key, hash_b64 in node_updates.items():
@@ -131,8 +115,8 @@ class MerkleNodeRepositoryImpl(MerkleNodeRepository):
                 state_json,
                 proof_json,
                 channel_json,
-                "1" if is_closed else "0",
-                str(created_at_ts),
+                "1" if channel.is_closed else "0",
+                str(channel.created_at.timestamp()),
             ]
         )
         result = await self._store.run_script(

--- a/src/nanomoni/infrastructure/vendor/payment_channel_repository_base_impl.py
+++ b/src/nanomoni/infrastructure/vendor/payment_channel_repository_base_impl.py
@@ -26,7 +26,7 @@ class PaymentChannelRepositoryBaseImpl(PaymentChannelRepositoryBase):
 
     def _deserialize_channel(self, raw: str) -> PaymentChannelBase:
         data = json.loads(raw)
-        if data.get("scheme") in ("payword", "paytree"):
+        if data.get("scheme") in ("payword", "paytree", "paytree_child_pair"):
             return PaymentChannel.model_validate(data)
         return SignaturePaymentChannel.model_validate(data)
 

--- a/src/nanomoni/infrastructure/vendor/vendor_client_async.py
+++ b/src/nanomoni/infrastructure/vendor/vendor_client_async.py
@@ -17,7 +17,9 @@ from ...application.vendor.payword_dtos import (
     ReceivePaywordPaymentDTO,
 )
 from ...application.vendor.paytree_dtos import (
+    PaytreeChildPairPaymentResponseDTO,
     PaytreePaymentResponseDTO,
+    ReceivePaytreeChildPairPaymentDTO,
     ReceivePaytreeStdPaymentDTO,
     ReceivePaytreeFirstOptPaymentDTO,
 )
@@ -178,6 +180,23 @@ class VendorClientAsync:
     ) -> None:
         """Ask the vendor to settle a first-opt PayTree payment channel."""
         path = f"/vendor/channels/paytree/first-opt/{dto.channel_id}/closure-requests"
+        await self._http.post(path, json=dto.model_dump())
+
+    async def send_paytree_child_pair_payment(
+        self,
+        channel_id: str,
+        dto: ReceivePaytreeChildPairPaymentDTO,
+    ) -> PaytreeChildPairPaymentResponseDTO:
+        """Send a child-pair PayTree payment to the vendor API."""
+        path = f"/vendor/channels/paytree/child-pair/{channel_id}/payments"
+        resp = await self._post_with_payment_retries(path, json=dto.model_dump())
+        return PaytreeChildPairPaymentResponseDTO.model_validate(resp.json())
+
+    async def request_settle_channel_paytree_child_pair(
+        self, dto: CloseChannelDTO
+    ) -> None:
+        """Ask the vendor to settle a child-pair PayTree payment channel."""
+        path = f"/vendor/channels/paytree/child-pair/{dto.channel_id}/closure-requests"
         await self._http.post(path, json=dto.model_dump())
 
     async def aclose(self) -> None:

--- a/src/nanomoni/protocol/__init__.py
+++ b/src/nanomoni/protocol/__init__.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from .paytree_child_pair import (
+    build_close_proof as build_child_pair_close_proof,
+    verify_close_proof as verify_child_pair_close_proof,
+    verify_payment as verify_child_pair_payment,
+)
 from .paytree_first_opt import (
     infer_subroot_index_for_incoming_pruned_merkle_proof,
     proof_indexes_first_opt,
@@ -14,10 +19,13 @@ from .paytree_standard import (
 )
 
 __all__ = [
+    "build_child_pair_close_proof",
     "infer_subroot_index_for_incoming_pruned_merkle_proof",
     "proof_indexes_first_opt",
     "proof_indexes_standard",
     "subroot_index_standard",
+    "verify_child_pair_close_proof",
+    "verify_child_pair_payment",
     "verify_proof",
     "verify_proof_with_leaf_hash",
 ]

--- a/src/nanomoni/protocol/paytree_child_pair.py
+++ b/src/nanomoni/protocol/paytree_child_pair.py
@@ -1,0 +1,65 @@
+"""PayTree child-pair protocol: per-payment child reveal + frontier close proof.
+
+Per payment k, the client reveals the two children of node k (Eytzinger
+index); the vendor accepts iff H(left, right) equals the hash it already
+knows for node k, then learns nodes 2k and 2k+1. Closing sends the most
+recently revealed child pair plus one "outer" sibling per remaining level up
+to the root, letting the issuer recompute the root in O(log N) without ever
+receiving a full per-payment proof.
+"""
+
+from __future__ import annotations
+
+from ..crypto.merkle_tree import hash_bytes, verify_proof_to_known_node
+from ..crypto.paytree_child_pair import children_of_k, sibling_of_k
+
+
+def verify_payment(known_parent: bytes, left: bytes, right: bytes) -> bool:
+    """Verify that (left, right) are the children of a node already known to equal known_parent."""
+    return hash_bytes(left + right) == known_parent
+
+
+def build_close_proof(
+    k: int, known: dict[int, bytes]
+) -> tuple[bytes, bytes, list[bytes]]:
+    """Build the frontier close proof for the vendor's most recently paid node k.
+
+    Returns (left, right, siblings) where (left, right) are the children of k
+    and siblings are the outer-sibling hashes walking from k up to (but not
+    including) the root, one per level. Raises KeyError if a required node is
+    missing from `known` (e.g. an out-of-order or incomplete payment history).
+    """
+    left_k, right_k = children_of_k(k)
+    left = known[left_k]
+    right = known[right_k]
+
+    siblings: list[bytes] = []
+    current = k
+    while current != 1:
+        siblings.append(known[sibling_of_k(current)])
+        current //= 2
+    return left, right, siblings
+
+
+def verify_close_proof(
+    root: bytes,
+    k: int,
+    left: bytes,
+    right: bytes,
+    siblings: list[bytes],
+) -> bool:
+    """Verify a frontier close proof: combine (left, right) into h_k, then walk to root.
+
+    Reuses `verify_proof_to_known_node`: h_k plays the role of the "leaf" hash
+    and k plays the role of the "leaf index" — the same even/odd-index parity
+    rule that picks combine order for a leaf's authentication path applies
+    identically when climbing from any Eytzinger index k to the root.
+    """
+    node = hash_bytes(left + right)
+    return verify_proof_to_known_node(
+        leaf_hash=node,
+        leaf_index=k,
+        siblings=siblings,
+        known_node_hash=root,
+        known_node_level=len(siblings),
+    )

--- a/src/nanomoni/protocol/paytree_child_pair.py
+++ b/src/nanomoni/protocol/paytree_child_pair.py
@@ -54,12 +54,25 @@ def verify_close_proof(
     and k plays the role of the "leaf index" — the same even/odd-index parity
     rule that picks combine order for a leaf's authentication path applies
     identically when climbing from any Eytzinger index k to the root.
+
+    The number of hops from k to the root (Eytzinger index 1) is fixed by k
+    itself (k.bit_length() - 1) and MUST NOT be taken from len(siblings): a
+    caller-controlled sibling count lets an attacker claim an inflated k that
+    is merely congruent to the real k modulo 2**len(siblings), which replays
+    the same hash chain without ever having reached the real root at k's true
+    depth. Rejecting any sibling count that doesn't match k's true distance
+    to the root closes that alias.
     """
+    if k < 1:
+        return False
+    expected_hops = k.bit_length() - 1
+    if len(siblings) != expected_hops:
+        return False
     node = hash_bytes(left + right)
     return verify_proof_to_known_node(
         leaf_hash=node,
         leaf_index=k,
         siblings=siblings,
         known_node_hash=root,
-        known_node_level=len(siblings),
+        known_node_level=expected_hops,
     )

--- a/tests/e2e/helpers/client_actor.py
+++ b/tests/e2e/helpers/client_actor.py
@@ -236,3 +236,55 @@ class ClientActor:
             ),
             paytree,
         )
+
+    def create_open_channel_request_paytree_child_pair(
+        self,
+        vendor_public_key_der_b64: str,
+        *,
+        amount: int,
+        unit_value: int,
+        max_i: int,
+    ) -> tuple[OpenChannelRequestDTO, Paytree]:
+        """
+        Create an open channel request for the child-pair PayTree mode.
+
+        `max_i` sizes the underlying tree (leaf count - 1), same as
+        `create_open_channel_request_paytree`. The *signed* `paytree_max_i`
+        field, however, carries the tree's `max_k` (number of internal
+        nodes) — child-pair payments are indexed by Eytzinger node index k,
+        not by leaf index — so it must be set before signing (not patched
+        onto the DTO afterwards, which would invalidate the signature).
+
+        Returns:
+            (OpenChannelRequestDTO, Paytree) so tests can generate proofs efficiently.
+        """
+        if unit_value <= 0:
+            raise ValueError("unit_value must be > 0")
+
+        paytree = Paytree.create(max_i=max_i)
+        root_b64 = paytree.commitment_root_b64
+        max_k = paytree.max_k
+
+        payload = PaytreeOpenChannelRequestPayload(
+            client_public_key_der_b64=self.public_key_der_b64,
+            vendor_public_key_der_b64=vendor_public_key_der_b64,
+            amount=amount,
+            paytree_root_b64=root_b64,
+            paytree_unit_value=unit_value,
+            paytree_max_i=max_k,
+        )
+        payload_bytes = json_to_bytes(payload.model_dump(exclude_none=True))
+        signature_b64 = sign_bytes(self.private_key, payload_bytes)
+
+        return (
+            OpenChannelRequestDTO(
+                client_public_key_der_b64=self.public_key_der_b64,
+                vendor_public_key_der_b64=vendor_public_key_der_b64,
+                amount=amount,
+                open_signature_b64=signature_b64,
+                paytree_root_b64=root_b64,
+                paytree_unit_value=unit_value,
+                paytree_max_i=max_k,
+            ),
+            paytree,
+        )

--- a/tests/fixtures/in_memory_storage.py
+++ b/tests/fixtures/in_memory_storage.py
@@ -171,8 +171,6 @@ class InMemoryKeyValueStore(KeyValueStore):
             return self._execute_save_channel_and_initial_payment_unified(keys, args)
         elif script_name_lower == "save_payment_with_nodes":
             return self._execute_save_payment_with_nodes(keys, args)
-        elif script_name_lower == "merkle_get_nodes_and_merge":
-            return self._execute_merkle_get_nodes_and_merge(keys, args)
         elif script_name_lower == "merkle_merge_nodes":
             return self._execute_merkle_merge_nodes(keys, args)
         elif script_name_lower == "save_signature_payment" or (
@@ -259,7 +257,7 @@ class InMemoryKeyValueStore(KeyValueStore):
             key=lambda x: x[1], reverse=True
         )
 
-        return [1, state_json]
+        return [1, ""]
 
     def _execute_create_channel(self, keys: List[str], args: List[str]) -> list[Any]:
         """Execute create_channel script logic."""
@@ -339,7 +337,7 @@ class InMemoryKeyValueStore(KeyValueStore):
             key=lambda x: x[1], reverse=True
         )
 
-        return [1, state_json]
+        return [1, ""]
 
     def _execute_save_payment_with_nodes(
         self, keys: List[str], args: List[str]
@@ -364,13 +362,13 @@ class InMemoryKeyValueStore(KeyValueStore):
         created_ts = float(args[base + 5]) if len(args) > base + 5 else 0.0
 
         # Monotonic CAS mirroring the Lua save_payment_with_nodes script.
-        old_is_closed = None
+        is_new_channel = True
         max_steps: Optional[int] = None
         prev = -1
         existing = self._data.get(channel_key)
         if existing:
+            is_new_channel = False
             ch = json.loads(existing)
-            old_is_closed = ch.get("is_closed")
             ms = ch.get("max_steps")
             max_steps = int(ms) if ms is not None else None
             last_ref = ch.get("last_proof_reference")
@@ -405,7 +403,7 @@ class InMemoryKeyValueStore(KeyValueStore):
         self._data[state_key] = state_json
         self._data[proof_key] = proof_json
 
-        if old_is_closed is None:
+        if is_new_channel:
             all_key = "payment_channels:all"
             target_key = closed_key if new_is_closed else open_key
             for key in (all_key, target_key):
@@ -416,44 +414,8 @@ class InMemoryKeyValueStore(KeyValueStore):
                 ]
                 self._sorted_sets[key].append((channel_id, created_ts))
                 self._sorted_sets[key].sort(key=lambda x: x[1], reverse=True)
-        elif old_is_closed != new_is_closed:
-            for key in (open_key, closed_key):
-                if key not in self._sorted_sets:
-                    self._sorted_sets[key] = []
-                self._sorted_sets[key] = [
-                    (m, s) for m, s in self._sorted_sets[key] if m != channel_id
-                ]
-            target_key = closed_key if new_is_closed else open_key
-            self._sorted_sets[target_key].append((channel_id, created_ts))
-            self._sorted_sets[target_key].sort(key=lambda x: x[1], reverse=True)
 
         return [1, str(new_ref)]
-
-    def _execute_merkle_get_nodes_and_merge(
-        self, keys: List[str], args: List[str]
-    ) -> list[Any]:
-        """Execute merkle_get_nodes_and_merge: MGET 2 keys, then MSET+ZADD with merkle_node: prefix."""
-        index_key = keys[0]
-        read_key_1 = keys[1]
-        read_key_2 = keys[2]
-        channel_id = args[0]
-        n = int(args[1]) if len(args) > 1 else 0
-        prefix = f"merkle_node:{channel_id}:"
-        read1 = self._data.get(read_key_1) or ""
-        read2 = self._data.get(read_key_2) or ""
-        for i in range(n):
-            suffix = args[2 + i * 2]
-            val = args[2 + i * 2 + 1]
-            full_key = prefix + suffix
-            self._data[full_key] = val
-            if index_key not in self._sorted_sets:
-                self._sorted_sets[index_key] = []
-            self._sorted_sets[index_key] = [
-                (m, s) for m, s in self._sorted_sets[index_key] if m != suffix
-            ]
-            self._sorted_sets[index_key].append((suffix, 0.0))
-            self._sorted_sets[index_key].sort(key=lambda x: x[1], reverse=True)
-        return [read1, read2]
 
     def _execute_merkle_merge_nodes(self, keys: List[str], args: List[str]) -> Any:
         """Execute merkle_merge_nodes: MSET + ZADD with merkle_node: prefix."""

--- a/tests/unit/crypto/test_paytree_child_pair_walkthrough.py
+++ b/tests/unit/crypto/test_paytree_child_pair_walkthrough.py
@@ -1,0 +1,126 @@
+"""Walkthrough of the PayTree child-pair protocol against the worked example.
+
+Mirrors the step-by-step example from the protocol write-up: an 8-leaf tree
+(h1 = root; h2, h3 = children of root; ...; h8..h15 = leaves). Payment k
+reveals the children of h_k; the vendor only ever needs nodes it already
+accumulated (no path back to the root is re-sent). Closing sends the most
+recently revealed child pair plus outer siblings up to the root.
+"""
+
+from __future__ import annotations
+
+from nanomoni.crypto.merkle_tree import build_merkle_tree, hash_bytes
+from nanomoni.crypto.paytree_child_pair import (
+    children_of_k,
+    max_k_for_depth,
+    node_hash_at_k,
+)
+from nanomoni.protocol import (
+    build_child_pair_close_proof,
+    verify_child_pair_close_proof,
+    verify_child_pair_payment,
+)
+
+LEAF_SECRETS: tuple[bytes, ...] = tuple(f"leaf{i}".encode() for i in range(8))
+NUM_LEAVES = len(LEAF_SECRETS)
+DEPTH = (NUM_LEAVES).bit_length() - 1  # 3
+
+
+def _build_tree() -> tuple[bytes, list[list[bytes]]]:
+    leaves = [hash_bytes(s) for s in LEAF_SECRETS]
+    return build_merkle_tree(leaves)
+
+
+def test_max_k_matches_number_of_internal_nodes() -> None:
+    # 8 leaves -> 7 internal nodes (h1..h7), each revealed by one payment.
+    assert max_k_for_depth(DEPTH) == 7
+
+
+def test_children_of_k_matches_eytzinger_heap_numbering() -> None:
+    assert children_of_k(1) == (2, 3)
+    assert children_of_k(2) == (4, 5)
+    assert children_of_k(3) == (6, 7)
+    assert children_of_k(4) == (8, 9)
+
+
+def test_child_pair_payments_and_progressive_close_examples() -> None:
+    """Reproduces payments 1-4 and their corresponding close proofs verbatim."""
+    root, tree_levels = _build_tree()
+
+    def h(k: int) -> bytes:
+        return node_hash_at_k(tree_levels, DEPTH, k)
+
+    known: dict[int, bytes] = {1: root}
+
+    # --- Payment 1: client sends (h2, h3) ---
+    left, right = h(2), h(3)
+    assert verify_child_pair_payment(known[1], left, right)
+    known[2], known[3] = left, right
+
+    # Close here: send (h2, h3); issuer checks H(h2,h3) == h1.
+    close_left, close_right, siblings = build_child_pair_close_proof(1, known)
+    assert (close_left, close_right, siblings) == (h(2), h(3), [])
+    assert verify_child_pair_close_proof(root, 1, close_left, close_right, siblings)
+
+    # --- Payment 2: client sends (h4, h5) ---
+    left, right = h(4), h(5)
+    assert verify_child_pair_payment(known[2], left, right)
+    known[4], known[5] = left, right
+
+    # Close here: send (h4, h5, h3); issuer computes h2=H(h4,h5), checks H(h2,h3)==h1.
+    close_left, close_right, siblings = build_child_pair_close_proof(2, known)
+    assert (close_left, close_right, siblings) == (h(4), h(5), [h(3)])
+    assert verify_child_pair_close_proof(root, 2, close_left, close_right, siblings)
+
+    # --- Payment 3: client sends (h6, h7) ---
+    left, right = h(6), h(7)
+    assert verify_child_pair_payment(known[3], left, right)
+    known[6], known[7] = left, right
+
+    # Close here: send (h2, h6, h7); issuer computes h3=H(h6,h7), checks H(h2,h3)==h1.
+    close_left, close_right, siblings = build_child_pair_close_proof(3, known)
+    assert (close_left, close_right, siblings) == (h(6), h(7), [h(2)])
+    assert verify_child_pair_close_proof(root, 3, close_left, close_right, siblings)
+
+    # --- Payment 4: client sends (h8, h9) ---
+    left, right = h(8), h(9)
+    assert verify_child_pair_payment(known[4], left, right)
+    known[8], known[9] = left, right
+
+    # Close here: send (h8, h9, h5, h3); issuer computes h4=H(h8,h9),
+    # then h2=H(h4,h5), then checks H(h2,h3)==h1.
+    close_left, close_right, siblings = build_child_pair_close_proof(4, known)
+    assert (close_left, close_right, siblings) == (h(8), h(9), [h(5), h(3)])
+    assert verify_child_pair_close_proof(root, 4, close_left, close_right, siblings)
+
+
+def test_full_bfs_payment_sequence_verifies_and_recovers_root() -> None:
+    """All payments 1..max_k verify in Eytzinger (BFS) order, using only known nodes."""
+    root, tree_levels = _build_tree()
+    max_k = max_k_for_depth(DEPTH)
+
+    known: dict[int, bytes] = {1: root}
+    for k in range(1, max_k + 1):
+        left_k, right_k = children_of_k(k)
+        left = node_hash_at_k(tree_levels, DEPTH, left_k)
+        right = node_hash_at_k(tree_levels, DEPTH, right_k)
+        assert verify_child_pair_payment(known[k], left, right)
+        known[left_k], known[right_k] = left, right
+
+        close_left, close_right, siblings = build_child_pair_close_proof(k, known)
+        assert verify_child_pair_close_proof(root, k, close_left, close_right, siblings)
+
+
+def test_verify_child_pair_payment_rejects_wrong_children() -> None:
+    root, tree_levels = _build_tree()
+    wrong_left = node_hash_at_k(tree_levels, DEPTH, 4)  # not a child of root
+    wrong_right = node_hash_at_k(tree_levels, DEPTH, 5)
+    assert not verify_child_pair_payment(root, wrong_left, wrong_right)
+
+
+def test_verify_close_proof_rejects_tampered_sibling() -> None:
+    root, tree_levels = _build_tree()
+    left = node_hash_at_k(tree_levels, DEPTH, 4)
+    right = node_hash_at_k(tree_levels, DEPTH, 5)
+    tampered_sibling = hash_bytes(b"not-h3")
+    assert not verify_child_pair_close_proof(root, 2, left, right, [tampered_sibling])

--- a/tests/unit/crypto/test_paytree_child_pair_walkthrough.py
+++ b/tests/unit/crypto/test_paytree_child_pair_walkthrough.py
@@ -124,3 +124,36 @@ def test_verify_close_proof_rejects_tampered_sibling() -> None:
     right = node_hash_at_k(tree_levels, DEPTH, 5)
     tampered_sibling = hash_bytes(b"not-h3")
     assert not verify_child_pair_close_proof(root, 2, left, right, [tampered_sibling])
+
+
+def test_verify_close_proof_rejects_index_relabeling_forgery() -> None:
+    """A genuine close proof for a real k must not also verify for a forged k'.
+
+    Regression test for a bypass where `known_node_level` was taken from
+    `len(siblings)` (caller-controlled) instead of from k's true distance to
+    the root. Since the combine order at each hop depends only on the
+    walked index's parity, any k' congruent to the real k modulo
+    2**len(siblings) replayed the identical hash chain and reached the real
+    root without ever having a genuine proof for k'. A vendor exploiting this
+    against the issuer's settlement endpoint could claim a k' far larger than
+    the real k (up to the channel's max_i) using proof bytes from one small
+    real payment, draining most of the channel's escrow.
+    """
+    root, tree_levels = _build_tree()
+
+    # Genuine close proof for k=2 (1 outer sibling: h3).
+    left = node_hash_at_k(tree_levels, DEPTH, 4)
+    right = node_hash_at_k(tree_levels, DEPTH, 5)
+    siblings = [node_hash_at_k(tree_levels, DEPTH, 3)]
+    assert verify_child_pair_close_proof(root, 2, left, right, siblings)
+
+    # Reusing the exact same (left, right, siblings), every k' congruent to
+    # 2 modulo 2**len(siblings)==2 must be rejected, not just accepted as a
+    # fluke of the honest k=2 case.
+    for forged_k in (4, 6, 8, 10, 12, 14):
+        assert not verify_child_pair_close_proof(
+            root, forged_k, left, right, siblings
+        )
+
+    # A k' with the wrong parity for the supplied siblings must also fail.
+    assert not verify_child_pair_close_proof(root, 3, left, right, siblings)

--- a/tests/use_cases/conftest.py
+++ b/tests/use_cases/conftest.py
@@ -20,9 +20,13 @@ from nanomoni.application.vendor.use_cases.paytree_std_payment import (
 from nanomoni.application.vendor.use_cases.paytree_first_opt_payment import (
     PaytreeFirstOptPaymentService,
 )
+from nanomoni.application.vendor.use_cases.paytree_child_pair_payment import (
+    PaytreeChildPairPaymentService,
+)
 from nanomoni.application.shared.paytree_scheme import (
     PaytreeStdCryptoScheme,
     PaytreeFirstOptCryptoScheme,
+    PaytreeChildPairCryptoScheme,
 )
 from nanomoni.infrastructure.vendor.merkle_node_repository_impl import (
     MerkleNodeRepositoryImpl,
@@ -195,6 +199,19 @@ def paytree_first_opt_channel_service(
     )
 
 
+@pytest.fixture
+def paytree_child_pair_channel_service(
+    issuer_account_repository: InMemoryAccountRepository,
+    issuer_payment_channel_repository: InMemoryIssuerPaymentChannelRepository,
+    issuer_private_key: ec.EllipticCurvePrivateKey,
+) -> PaytreeChannelService:
+    return PaytreeChannelService(
+        account_repo=issuer_account_repository,
+        channel_repo=issuer_payment_channel_repository,
+        issuer_private_key=issuer_private_key,
+    )
+
+
 # ============================================================================
 # Issuer Client Adapter Fixtures
 # ============================================================================
@@ -207,6 +224,7 @@ def issuer_client(
     payword_channel_service: PaywordChannelService,
     paytree_std_channel_service: PaytreeChannelService,
     paytree_first_opt_channel_service: PaytreeChannelService,
+    paytree_child_pair_channel_service: PaytreeChannelService,
 ) -> UseCaseIssuerClient:
     return UseCaseIssuerClient(
         registration_service=registration_service,
@@ -214,6 +232,7 @@ def issuer_client(
         payword_channel_service=payword_channel_service,
         paytree_std_channel_service=paytree_std_channel_service,
         paytree_first_opt_channel_service=paytree_first_opt_channel_service,
+        paytree_child_pair_channel_service=paytree_child_pair_channel_service,
     )
 
 
@@ -224,6 +243,7 @@ def issuer_client_factory(
     payword_channel_service: PaywordChannelService,
     paytree_std_channel_service: PaytreeChannelService,
     paytree_first_opt_channel_service: PaytreeChannelService,
+    paytree_child_pair_channel_service: PaytreeChannelService,
 ) -> IssuerClientFactory:
     def factory() -> IssuerClientProtocol:
         client: IssuerClientProtocol = UseCaseIssuerClient(
@@ -232,6 +252,7 @@ def issuer_client_factory(
             payword_channel_service=payword_channel_service,
             paytree_std_channel_service=paytree_std_channel_service,
             paytree_first_opt_channel_service=paytree_first_opt_channel_service,
+            paytree_child_pair_channel_service=paytree_child_pair_channel_service,
         )
         return client
 
@@ -320,6 +341,23 @@ def paytree_first_opt_payment_service(
     )
 
 
+@pytest.fixture
+def paytree_child_pair_payment_service(
+    vendor_payment_repositories: VendorPaymentRepositories,
+    issuer_client_factory: IssuerClientFactory,
+    vendor_public_key_der_b64: str,
+    vendor_private_key_pem: str,
+) -> PaytreeChildPairPaymentService:
+    return PaytreeChildPairPaymentService(
+        payment_repository=vendor_payment_repositories.payment,
+        issuer_client_factory=issuer_client_factory,
+        vendor_public_key_der_b64=vendor_public_key_der_b64,
+        crypto_scheme=PaytreeChildPairCryptoScheme(),
+        node_repo=MerkleNodeRepositoryImpl(vendor_payment_repositories.store),
+        vendor_private_key_pem=vendor_private_key_pem,
+    )
+
+
 # ============================================================================
 # Vendor Client Adapter Fixtures
 # ============================================================================
@@ -331,6 +369,7 @@ def vendor_client(
     payword_payment_service: PaywordPaymentService,
     paytree_std_payment_service: PaytreeStdPaymentService,
     paytree_first_opt_payment_service: PaytreeFirstOptPaymentService,
+    paytree_child_pair_payment_service: PaytreeChildPairPaymentService,
     vendor_public_key_der_b64: str,
 ) -> UseCaseVendorClient:
     return UseCaseVendorClient(
@@ -338,5 +377,6 @@ def vendor_client(
         payword_payment_service=payword_payment_service,
         paytree_std_payment_service=paytree_std_payment_service,
         paytree_first_opt_payment_service=paytree_first_opt_payment_service,
+        paytree_child_pair_payment_service=paytree_child_pair_payment_service,
         vendor_public_key_der_b64=vendor_public_key_der_b64,
     )

--- a/tests/use_cases/helpers/issuer_client_adapter.py
+++ b/tests/use_cases/helpers/issuer_client_adapter.py
@@ -26,6 +26,7 @@ from nanomoni.application.issuer.payword_dtos import (
     PaywordSettlementRequestDTO,
 )
 from nanomoni.application.issuer.paytree_dtos import (
+    PaytreeChildPairSettlementRequestDTO,
     PaytreeOpenChannelResponseDTO,
     PaytreePaymentChannelResponseDTO,
     PaytreeSettlementRequestDTO,
@@ -63,12 +64,16 @@ class UseCaseIssuerClient:
         payword_channel_service: PaywordChannelService,
         paytree_std_channel_service: PaytreeChannelService,
         paytree_first_opt_channel_service: PaytreeChannelService,
+        paytree_child_pair_channel_service: PaytreeChannelService | None = None,
     ) -> None:
         self.registration_service = registration_service
         self.payment_channel_service = payment_channel_service
         self.payword_channel_service = payword_channel_service
         self.paytree_std_channel_service = paytree_std_channel_service
         self.paytree_first_opt_channel_service = paytree_first_opt_channel_service
+        self.paytree_child_pair_channel_service = (
+            paytree_child_pair_channel_service or paytree_std_channel_service
+        )
 
     async def register(self, dto: RegistrationRequestDTO) -> RegistrationResponseDTO:
         return await self.registration_service.register(dto)
@@ -183,6 +188,30 @@ class UseCaseIssuerClient:
         self, channel_id: str, dto: PaytreeSettlementRequestDTO
     ) -> CloseChannelResponseDTO:
         return await self.paytree_first_opt_channel_service.settle_channel(
+            channel_id, dto
+        )
+
+    # PayTree Child-Pair
+
+    async def open_paytree_child_pair_payment_channel(
+        self, dto: OpenChannelRequestDTO
+    ) -> PaytreeOpenChannelResponseDTO:
+        return await self.paytree_child_pair_channel_service.open_channel(dto)
+
+    async def open_paytree_child_pair_channel(
+        self, dto: OpenChannelRequestDTO
+    ) -> PaytreeOpenChannelResponseDTO:
+        return await self.paytree_child_pair_channel_service.open_channel(dto)
+
+    async def get_paytree_child_pair_payment_channel(
+        self, dto: GetPaymentChannelRequestDTO
+    ) -> PaytreePaymentChannelResponseDTO:
+        return await self.paytree_child_pair_channel_service.get_channel(dto)
+
+    async def settle_paytree_child_pair_payment_channel(
+        self, channel_id: str, dto: PaytreeChildPairSettlementRequestDTO
+    ) -> CloseChannelResponseDTO:
+        return await self.paytree_child_pair_channel_service.settle_channel_child_pair(
             channel_id, dto
         )
 

--- a/tests/use_cases/helpers/vendor_client_adapter.py
+++ b/tests/use_cases/helpers/vendor_client_adapter.py
@@ -17,6 +17,8 @@ from nanomoni.application.vendor.payword_dtos import (
     PaywordPaymentResponseDTO,
 )
 from nanomoni.application.vendor.paytree_dtos import (
+    PaytreeChildPairPaymentResponseDTO,
+    ReceivePaytreeChildPairPaymentDTO,
     ReceivePaytreeStdPaymentDTO,
     ReceivePaytreeFirstOptPaymentDTO,
     PaytreePaymentResponseDTO,
@@ -30,6 +32,9 @@ from nanomoni.application.vendor.use_cases.paytree_std_payment import (
 )
 from nanomoni.application.vendor.use_cases.paytree_first_opt_payment import (
     PaytreeFirstOptPaymentService,
+)
+from nanomoni.application.vendor.use_cases.paytree_child_pair_payment import (
+    PaytreeChildPairPaymentService,
 )
 
 
@@ -56,11 +61,14 @@ class UseCaseVendorClient:
         paytree_std_payment_service: PaytreeStdPaymentService,
         paytree_first_opt_payment_service: PaytreeFirstOptPaymentService,
         vendor_public_key_der_b64: str,
+        paytree_child_pair_payment_service: PaytreeChildPairPaymentService
+        | None = None,
     ) -> None:
         self.payment_service = payment_service
         self.payword_payment_service = payword_payment_service
         self.paytree_std_payment_service = paytree_std_payment_service
         self.paytree_first_opt_payment_service = paytree_first_opt_payment_service
+        self.paytree_child_pair_payment_service = paytree_child_pair_payment_service
         self.vendor_public_key_der_b64 = vendor_public_key_der_b64
 
     async def get_public_key(self) -> VendorPublicKeyDTO:
@@ -184,6 +192,31 @@ class UseCaseVendorClient:
             return UseCaseResponse(
                 status_code=400, content=json.dumps({"detail": str(e)}).encode("utf-8")
             )
+
+    # PayTree Child-Pair
+
+    async def receive_paytree_child_pair_payment(
+        self,
+        channel_id: str,
+        *,
+        k: int,
+        left_b64: str,
+        right_b64: str,
+    ) -> PaytreeChildPairPaymentResponseDTO:
+        assert self.paytree_child_pair_payment_service is not None
+        dto = ReceivePaytreeChildPairPaymentDTO(
+            k=k, left_b64=left_b64, right_b64=right_b64
+        )
+        return await self.paytree_child_pair_payment_service.receive_payment(
+            channel_id, dto
+        )
+
+    async def request_channel_settlement_paytree_child_pair(
+        self, channel_id: str
+    ) -> None:
+        assert self.paytree_child_pair_payment_service is not None
+        dto = CloseChannelDTO(channel_id=channel_id)
+        await self.paytree_child_pair_payment_service.settle_channel(dto)
 
     # Generic raw helpers
 

--- a/tests/use_cases/stories/test_complete_paytree_child_pair_flow.py
+++ b/tests/use_cases/stories/test_complete_paytree_child_pair_flow.py
@@ -1,0 +1,102 @@
+"""Story: PayTree child-pair flow — open, pay via heap-indexed child reveal, settle.
+
+Mirrors test_complete_paytree_first_opt_flow_settle.py but for the child-pair
+protocol: payment k reveals the two children of node k (Eytzinger index),
+verified against the vendor's already-known hash for node k (starting from
+the root). Settlement sends a frontier proof (most recent child pair + outer
+siblings up to the root), not a full leaf->root proof.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nanomoni.application.issuer.dtos import GetPaymentChannelRequestDTO
+from tests.e2e.helpers.client_actor import ClientActor
+from tests.use_cases.helpers.issuer_client_adapter import UseCaseIssuerClient
+from tests.use_cases.helpers.vendor_client_adapter import UseCaseVendorClient
+
+
+@pytest.mark.asyncio
+async def test_paytree_child_pair_full_bfs_sequence_settles_successfully(
+    issuer_client: UseCaseIssuerClient,
+    vendor_client: UseCaseVendorClient,
+) -> None:
+    client = ClientActor()
+
+    await issuer_client.register_account(client.public_key_der_b64)
+    vendor_pk = await vendor_client.get_public_key()
+    await issuer_client.register_account(vendor_pk.public_key_der_b64)
+
+    channel_amount = 10_000
+    unit_value = 2
+    max_i = 7  # 8-leaf tree -> max_k = 7 internal nodes
+
+    open_request, paytree = client.create_open_channel_request_paytree_child_pair(
+        vendor_pk.public_key_der_b64,
+        amount=channel_amount,
+        unit_value=unit_value,
+        max_i=max_i,
+    )
+    channel_response = await issuer_client.open_paytree_child_pair_channel(open_request)
+    channel_id = channel_response.channel_id
+    assert channel_response.paytree_max_i == paytree.max_k
+
+    for k in range(1, paytree.max_k + 1):
+        k_val, left_b64, right_b64 = paytree.payment_proof_child_pair(k)
+        resp = await vendor_client.receive_paytree_child_pair_payment(
+            channel_id, k=k_val, left_b64=left_b64, right_b64=right_b64
+        )
+        assert resp.channel_id == channel_id
+        assert resp.k == k
+        assert resp.cumulative_owed_amount == k * unit_value
+
+    await vendor_client.request_channel_settlement_paytree_child_pair(channel_id)
+
+    channel_state = await issuer_client.get_paytree_child_pair_payment_channel(
+        GetPaymentChannelRequestDTO(channel_id=channel_id)
+    )
+    assert channel_state.is_closed is True
+    assert channel_state.balance == paytree.max_k * unit_value
+
+
+@pytest.mark.asyncio
+async def test_paytree_child_pair_partial_sequence_settles_with_frontier_proof(
+    issuer_client: UseCaseIssuerClient,
+    vendor_client: UseCaseVendorClient,
+) -> None:
+    """Closing mid-sequence must succeed using only the frontier proof (no full leaf proof)."""
+    client = ClientActor()
+
+    await issuer_client.register_account(client.public_key_der_b64)
+    vendor_pk = await vendor_client.get_public_key()
+    await issuer_client.register_account(vendor_pk.public_key_der_b64)
+
+    channel_amount = 10_000
+    unit_value = 1
+    max_i = 7
+
+    open_request, paytree = client.create_open_channel_request_paytree_child_pair(
+        vendor_pk.public_key_der_b64,
+        amount=channel_amount,
+        unit_value=unit_value,
+        max_i=max_i,
+    )
+    channel_response = await issuer_client.open_paytree_child_pair_channel(open_request)
+    channel_id = channel_response.channel_id
+
+    # Only pay through k=4 (as in the write-up's worked example): the vendor
+    # never has a leaf hash yet, but it does have h4's children (h8, h9).
+    for k in range(1, 5):
+        k_val, left_b64, right_b64 = paytree.payment_proof_child_pair(k)
+        await vendor_client.receive_paytree_child_pair_payment(
+            channel_id, k=k_val, left_b64=left_b64, right_b64=right_b64
+        )
+
+    await vendor_client.request_channel_settlement_paytree_child_pair(channel_id)
+
+    channel_state = await issuer_client.get_paytree_child_pair_payment_channel(
+        GetPaymentChannelRequestDTO(channel_id=channel_id)
+    )
+    assert channel_state.is_closed is True
+    assert channel_state.balance == 4 * unit_value

--- a/tests/use_cases/test_paytree_child_pair_monotonic_cas.py
+++ b/tests/use_cases/test_paytree_child_pair_monotonic_cas.py
@@ -1,0 +1,147 @@
+"""Regression-style coverage: child-pair PayTree save enforces an atomic monotonic CAS.
+
+Child-pair payments reuse the exact same `save_nodes_and_payment` atomic
+save as first-opt (see test_paytree_first_opt_monotonic_cas.py) — node_updates
+is just an opaque str->str dict, so no scheme-specific Lua changes were
+needed. This test locks in that the CAS semantics (reject stale/non-increasing
+k, reject k beyond max_k, register new channels in the open/closed indexes)
+also hold when node keys are child-pair-style (`str(k)`).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+
+from nanomoni.domain.shared.proof_reference import PaymentScheme
+from nanomoni.domain.vendor.entities import PaymentChannel, PaymentState
+from nanomoni.infrastructure.scripts import VENDOR_SCRIPTS
+from nanomoni.infrastructure.vendor.merkle_node_repository_impl import (
+    MerkleNodeRepositoryImpl,
+)
+from tests.fixtures.in_memory_storage import InMemoryKeyValueStore
+
+
+async def _new_repo() -> tuple[InMemoryKeyValueStore, MerkleNodeRepositoryImpl]:
+    store = InMemoryKeyValueStore()
+    for name, script in VENDOR_SCRIPTS.items():
+        await store.register_script(name, script)
+    return store, MerkleNodeRepositoryImpl(store)
+
+
+def _make_channel(
+    channel_id: str, *, max_steps: int, last_ref: Optional[int]
+) -> PaymentChannel:
+    return PaymentChannel(
+        channel_id=channel_id,
+        client_public_key_der_b64="client",
+        vendor_public_key_der_b64="vendor",
+        salt_b64="salt",
+        amount=10_000,
+        balance=0,
+        is_closed=False,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        commitment="root",
+        scheme=PaymentScheme.PAYTREE_CHILD_PAIR,
+        max_steps=max_steps,
+        unit_value=1,
+        last_proof_reference=last_ref,
+    )
+
+
+def _make_state(channel_id: str, k: int) -> PaymentState:
+    return PaymentState(
+        channel_id=channel_id,
+        proof_reference=k,
+        cumulative_owed=k,
+        proof_fingerprint=f"left-{k}:right-{k}",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+async def _save(
+    repo: MerkleNodeRepositoryImpl, channel: PaymentChannel, k: int
+) -> tuple[int, Optional[int]]:
+    """Emulate the child-pair use case: node_updates keyed by str(2k)/str(2k+1)."""
+    channel.last_proof_reference = k
+    state = _make_state(channel.channel_id, k)
+    node_updates = {str(2 * k): f"left-{k}", str(2 * k + 1): f"right-{k}"}
+    return await repo.save_nodes_and_payment(
+        channel_id=channel.channel_id,
+        node_updates=node_updates,
+        new_ref=k,
+        channel_json=channel.model_dump_json(),
+        state_json=state.model_dump_json(),
+        proof_json="{}",
+        is_closed=False,
+        created_at_ts=channel.created_at.timestamp(),
+    )
+
+
+async def _stored_ref(store: InMemoryKeyValueStore, channel_id: str) -> Optional[int]:
+    raw = await store.get(f"payment_state:{channel_id}")
+    if not raw:
+        return None
+    return int(json.loads(raw)["proof_reference"])
+
+
+@pytest.mark.asyncio
+async def test_child_pair_save_rejects_stale_reference() -> None:
+    store, repo = await _new_repo()
+
+    status, ref = await _save(repo, _make_channel("c1", max_steps=7, last_ref=None), 3)
+    assert (status, ref) == (1, 3)
+
+    status, ref = await _save(repo, _make_channel("c1", max_steps=7, last_ref=3), 2)
+    assert status == 0
+    assert ref == 3
+    assert await _stored_ref(store, "c1") == 3
+
+
+@pytest.mark.asyncio
+async def test_child_pair_save_prevents_reorder_double_write() -> None:
+    store, repo = await _new_repo()
+
+    await _save(repo, _make_channel("c1", max_steps=7, last_ref=None), 3)
+
+    status_a, _ = await _save(repo, _make_channel("c1", max_steps=7, last_ref=3), 4)
+    assert status_a == 1
+
+    status_b, ref_b = await _save(repo, _make_channel("c1", max_steps=7, last_ref=3), 4)
+    assert status_b == 0
+    assert ref_b == 4
+    assert await _stored_ref(store, "c1") == 4
+
+
+@pytest.mark.asyncio
+async def test_child_pair_save_rejects_reference_beyond_max_k() -> None:
+    store, repo = await _new_repo()
+
+    status, _ = await _save(repo, _make_channel("c1", max_steps=7, last_ref=None), 8)
+    assert status == 3
+    assert await _stored_ref(store, "c1") is None
+
+
+@pytest.mark.asyncio
+async def test_child_pair_save_registers_new_channel_in_indexes() -> None:
+    store, repo = await _new_repo()
+
+    status, _ = await _save(repo, _make_channel("c1", max_steps=7, last_ref=None), 1)
+    assert status == 1
+
+    assert "c1" in await store.zrevrange("payment_channels:all", 0, -1)
+    assert "c1" in await store.zrevrange("payment_channels:open", 0, -1)
+    assert "c1" not in await store.zrevrange("payment_channels:closed", 0, -1)
+
+
+@pytest.mark.asyncio
+async def test_child_pair_node_keys_are_plain_k_strings() -> None:
+    """Node keys are `str(2k)`/`str(2k+1)` — no depth/level math required to store them."""
+    store, repo = await _new_repo()
+    await _save(repo, _make_channel("c1", max_steps=7, last_ref=None), 2)
+
+    nodes = await repo.get_nodes("c1", ["4", "5"])
+    assert nodes == {"4": "left-2", "5": "right-2"}

--- a/tests/use_cases/test_paytree_child_pair_monotonic_cas.py
+++ b/tests/use_cases/test_paytree_child_pair_monotonic_cas.py
@@ -16,6 +16,7 @@ from typing import Optional
 
 import pytest
 
+from nanomoni.domain.shared.crypto_proof import CryptoProof
 from nanomoni.domain.shared.proof_reference import PaymentScheme
 from nanomoni.domain.vendor.entities import PaymentChannel, PaymentState
 from nanomoni.infrastructure.scripts import VENDOR_SCRIPTS
@@ -69,15 +70,14 @@ async def _save(
     channel.last_proof_reference = k
     state = _make_state(channel.channel_id, k)
     node_updates = {str(2 * k): f"left-{k}", str(2 * k + 1): f"right-{k}"}
+    proof = CryptoProof(scheme=PaymentScheme.PAYTREE_CHILD_PAIR, data={})
     return await repo.save_nodes_and_payment(
         channel_id=channel.channel_id,
         node_updates=node_updates,
         new_ref=k,
-        channel_json=channel.model_dump_json(),
-        state_json=state.model_dump_json(),
-        proof_json="{}",
-        is_closed=False,
-        created_at_ts=channel.created_at.timestamp(),
+        channel=channel,
+        state=state,
+        proof=proof,
     )
 
 

--- a/tests/use_cases/test_paytree_first_opt_monotonic_cas.py
+++ b/tests/use_cases/test_paytree_first_opt_monotonic_cas.py
@@ -98,7 +98,9 @@ async def test_first_opt_save_rejects_stale_reference() -> None:
     store, repo = await _new_repo()
 
     # First payment i=5 succeeds and becomes the committed reference.
-    status, ref = await _save(repo, _make_channel("c1", max_steps=128, last_ref=None), 5)
+    status, ref = await _save(
+        repo, _make_channel("c1", max_steps=128, last_ref=None), 5
+    )
     assert (status, ref) == (1, 5)
 
     # A concurrent request that read prev=5 but arrives with a lower i must be
@@ -132,7 +134,9 @@ async def test_first_opt_save_prevents_reorder_double_write() -> None:
 async def test_first_opt_save_rejects_reference_beyond_max_steps() -> None:
     store, repo = await _new_repo()
 
-    status, _ = await _save(repo, _make_channel("c1", max_steps=128, last_ref=None), 200)
+    status, _ = await _save(
+        repo, _make_channel("c1", max_steps=128, last_ref=None), 200
+    )
     assert status == 3
     assert await _stored_ref(store, "c1") is None
 

--- a/tests/use_cases/test_paytree_first_opt_monotonic_cas.py
+++ b/tests/use_cases/test_paytree_first_opt_monotonic_cas.py
@@ -22,6 +22,7 @@ from typing import Optional
 
 import pytest
 
+from nanomoni.domain.shared.crypto_proof import CryptoProof
 from nanomoni.domain.shared.proof_reference import PaymentScheme
 from nanomoni.domain.vendor.entities import PaymentChannel, PaymentState
 from nanomoni.infrastructure.scripts import VENDOR_SCRIPTS
@@ -74,15 +75,14 @@ async def _save(
     """Emulate the use case: embed the new reference in the channel, then save."""
     channel.last_proof_reference = ref
     state = _make_state(channel.channel_id, ref)
+    proof = CryptoProof(scheme=PaymentScheme.PAYTREE, data={})
     return await repo.save_nodes_and_payment(
         channel_id=channel.channel_id,
         node_updates={},
         new_ref=ref,
-        channel_json=channel.model_dump_json(),
-        state_json=state.model_dump_json(),
-        proof_json="{}",
-        is_closed=False,
-        created_at_ts=channel.created_at.timestamp(),
+        channel=channel,
+        state=state,
+        proof=proof,
     )
 
 


### PR DESCRIPTION
## Summary
- Adds PayTree Child-Pair payment mode (Merkle child-pair proof verification, monotonic CAS on save).
- Adds PayTree First-Opt payment mode with pruned-proof support, and fixes a verification bypass for empty siblings in that scheme.
- Consolidates PayTree optimization type handling and repository structure.
- Refactors `save_nodes_and_payment`/`get_channel_and_nodes` to pass typed domain objects (`PaymentChannel`/`PaymentState`/`CryptoProof`) instead of pre-serialized JSON, moving serialization into the repository.

## Known issue carried over (not fixed in this PR)
`MerkleNodeRepository.delete()` is defined but never invoked from any use case or router on channel close, so vendor Redis memory for PayTree Child-Pair/First-Opt channels grows unboundedly across benchmark runs. A follow-up PR (#2, stacked on this one) works around it operationally with a `redis-cli flushall` between benchmark runs, but the underlying leak is still open.

## Test plan
- [ ] `poetry run pytest tests/use_cases`
- [ ] `poetry run pytest -m e2e tests/e2e` (all 4 services up)
- [ ] `bash scripts/lint.sh && poetry run mypy src/nanomoni`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PayTree Child-Pair payment channels, supporting channel opening, payments, retrieval, settlement, and closure.
  * Added client support for generating and submitting verified child-pair payment proofs.
  * Added validation for payment limits, ordering, duplicate references, and settlement proofs.
* **Benchmarking**
  * Added PayTree Child-Pair benchmark execution and latency/TPS reporting.
* **Bug Fixes**
  * Improved payment persistence and channel handling for existing PayTree payment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->