### PR TITLE
Pin workers/clients to CPU cores; scale across ports and processes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 envs/env.sh
 .git
 __pycache__
-dist 
+dist
+.data 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 envs/*.env.sh
+.data/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -221,6 +222,7 @@ __marimo__/
 runs_metadata.json
 
 benchmark_timing.json
+tps_saturation_timing.json
 plots/
 report/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 envs/*.env.sh
-.data/
+.data/*
+!.data/prometheus/
+!.data/prometheus/.gitkeep
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -130,10 +130,29 @@ Issuer and vendor will start their Redis dependencies via `depends_on`.
 ```sh
 docker compose build
 
-source ./envs/issuer.env.sh && docker compose up issuer -d
-source ./envs/vendor.env.sh && docker compose up vendor -d
-source ./envs/client.env.sh && docker compose up client -d
+source ./envs/issuer.env.sh && docker compose up issuer -d --build
+source ./envs/vendor.env.sh && docker compose up vendor -d --build
+source ./envs/client.env.sh && docker compose up client -d --build
 ```
+
+### Vendor worker ports
+
+With `VENDOR_API_WORKERS=N` the vendor runs N single-worker servers on
+consecutive ports from `VENDOR_API_PORT` (so `8000..8011` for the benchmark
+layout), one listening socket each, instead of N workers sharing one socket. A
+keep-alive connection is served end to end by the worker that accepted it, so the
+port a client dials is the worker it reaches — which is what lets the load
+generator spread itself evenly (`CLIENT_VENDOR_PORT_COUNT`) instead of leaving
+the kernel to pile connections onto a few workers.
+
+Only `8000` is published to the host; the rest of the range would collide with
+the issuer on 8001 and the client's metrics on 8002. For the same reason the
+local-dev and example env scripts keep `VENDOR_API_WORKERS=1`. See
+[docs/worker-affinity-and-saturation.md](docs/worker-affinity-and-saturation.md)
+for the reasoning and the measurements,
+[docs/benchmark-ceiling-and-what-remains.md](docs/benchmark-ceiling-and-what-remains.md)
+for where the ceiling ends up and what holds it, and [tuning.md](tuning.md) for the
+core layout.
 
 ## Publishing Docker images
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,17 @@
 services:
   client:
+    # 4 cores reservados, um por processo (CLIENT_PROCESSES=4), fora do cpuset do
+    # vendor -- o payment loop e sequencial, entao preempcao aqui vira latencia
+    # aparente do vendor. 12-14 sao CCX2 (L3 12-17,36-41); 21 vem do bloco de
+    # monitoramento para acompanhar os 12 cores do vendor e manter o 3:1.
+    cpuset: "12-14,21"
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.client
     environment:
       VENDOR_BASE_URL: ${VENDOR_BASE_URL}
       ISSUER_BASE_URL: ${ISSUER_BASE_URL}
-      CLIENT_PRIVATE_KEY_PEM: ${CLIENT_PRIVATE_KEY_PEM}
+      CLIENT_PRIVATE_KEY_PEMS: ${CLIENT_PRIVATE_KEY_PEMS}
       CLIENT_PAYMENT_COUNT: ${CLIENT_PAYMENT_COUNT}
       CLIENT_CHANNEL_AMOUNT: ${CLIENT_CHANNEL_AMOUNT}
       CLIENT_PAYMENT_MODE: ${CLIENT_PAYMENT_MODE}
@@ -16,10 +21,15 @@ services:
       CLIENT_PAYTREE_MAX_I: ${CLIENT_PAYTREE_MAX_I}
       CLIENT_TARGET_TPS: ${CLIENT_TARGET_TPS}
       CLIENT_RAMP_DELAY_SEC: ${CLIENT_RAMP_DELAY_SEC}
+      CLIENT_PROCESSES: ${CLIENT_PROCESSES}
+      CLIENT_PIN_PROCESSES_TO_CORES: ${CLIENT_PIN_PROCESSES_TO_CORES}
+      CLIENT_VENDOR_PORT_COUNT: ${CLIENT_VENDOR_PORT_COUNT}
     networks:
       - app-network
 
   issuer:
+    # CCX2 (L3 12-17,36-41): mesmo L3 que redis-issuer
+    cpuset: "16"
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.issuer
@@ -42,6 +52,16 @@ services:
       - app-network
 
   vendor:
+    # 12 cores fisicos, um por worker (VENDOR_API_WORKERS=12), fixados 1:1 por
+    # VENDOR_PIN_WORKERS_TO_CORES. Invariante do layout: o vendor recebe no
+    # minimo 3 cores por core do client (aqui 12:4). O resto da maquina esta
+    # reservado aos vizinhos que nao podem sofrer contencao -- redis-vendor
+    # (11,18), client (12-14,21), issuer (16), redis-issuer (17), monitoramento
+    # (22-23) -- e ao housekeeping em 0 (boot CPU) e 15, que recebem as IRQs (ver
+    # tuning.md). 19-20 saem do bloco de monitoramento e ficam em outro L3 (CCX3)
+    # que 1-10: cada worker e um processo independente com sua propria conexao,
+    # entao nao compartilham working set e a distancia de L3 nao os acopla.
+    cpuset: "1-10,19-20"
     build:
       context: .
       dockerfile: dockerfiles/Dockerfile.vendor
@@ -53,12 +73,19 @@ services:
       VENDOR_API_DEBUG: ${VENDOR_API_DEBUG}
       VENDOR_API_CORS_ORIGINS: ${VENDOR_API_CORS_ORIGINS}
       VENDOR_API_WORKERS: ${VENDOR_API_WORKERS}
+      VENDOR_PIN_WORKERS_TO_CORES: ${VENDOR_PIN_WORKERS_TO_CORES}
       VENDOR_APP_NAME: ${VENDOR_APP_NAME}
       VENDOR_APP_VERSION: ${VENDOR_APP_VERSION}
       VENDOR_PRIVATE_KEY_PEM: ${VENDOR_PRIVATE_KEY_PEM}
       ISSUER_BASE_URL: ${ISSUER_BASE_URL}
       PROMETHEUS_MULTIPROC_DIR: ${PROMETHEUS_MULTIPROC_DIR}
     ports:
+      # Only the first worker's port is published: the others (8001..8009 inside
+      # the container, one listening socket per worker) would collide on the host
+      # with the issuer on 8001 and the client's metrics on 8002. Nothing needs
+      # them from the host -- the client dials vendor:800N over the compose
+      # network, and Prometheus keeps scraping :8000, where /metrics aggregates
+      # every worker through PROMETHEUS_MULTIPROC_DIR.
       - 8000:8000
     depends_on:
       - redis-vendor
@@ -66,36 +93,65 @@ services:
       - app-network
 
   redis-vendor:
+    # 11 e CCX1 (L3 6-11,30-35), mesmo L3 que os workers do vendor em 6-10: core
+    # reservado porque o Redis e single-threaded. O segundo core existe para o
+    # filho de rewrite do AOF, que e um fork e herda este cpuset: com um core so,
+    # ele disputava de igual para igual com a thread que atende os pagamentos e
+    # saturava o core (medido: 100% no core, metade dele so o rewrite). Vem do
+    # bloco de monitoramento (CCX3, 22-23 agora) e nao do vendor ou do client,
+    # que estao no caminho medido -- e ficar em outro L3 e desejavel, porque o
+    # rewrite varre o dataset inteiro e despejaria o L3 da thread que atende.
+    cpuset: "11,18"
     image: redis:7-alpine
     command: ["redis-server", "--appendonly", "yes"]
     ports:
       - 6379:6379
     volumes:
-      - redis_vendor_data:/data
+      - ./.data/redis-vendor:/data
     networks:
       - app-network
 
   redis-issuer:
+    # CCX2 (L3 12-17,36-41): mesmo L3 que o issuer (core dedicado)
+    cpuset: "17"
     image: redis:7-alpine
     command: ["redis-server", "--appendonly", "yes"]
     ports:
       - 6380:6379
     volumes:
-      - redis_issuer_data:/data
+      - ./.data/redis-issuer:/data
     networks:
       - app-network
 
   pyroscope:
+    # CCX3 (L3 18-23,42-47): monitoramento longe do caminho crítico. O bloco cedeu
+    # 18 ao redis-vendor, 19-20 ao vendor e 21 ao client, e ficou com 22-23.
+    cpuset: "22-23"
     image: grafana/pyroscope:latest
     command: ["server", "--http-address=:4040"]
     ports:
       - 4040:4040
+    # These three paths are where Pyroscope actually writes (it does not use
+    # /var/lib/pyroscope), and its image declares all three as VOLUME. Left
+    # unnamed, Docker gives each container run a *fresh anonymous* volume, so
+    # recreating the container silently starts from an empty profile store --
+    # that is how the 20260803_192658 run's profiles were lost, and an empty
+    # store reads back as a valid all-zero profile rather than as an error.
+    # Named volumes are reused across recreation. Unlike the bind mounts
+    # elsewhere in this file, they also inherit the image's uid 10001 ownership;
+    # a fresh host directory would be root-owned and Pyroscope could not write
+    # to it. Still destroyed by `docker compose down -v`.
     volumes:
-      - pyroscope_data:/var/lib/pyroscope
+      - pyroscope-data:/data
+      - pyroscope-compactor:/data-compactor
+      - pyroscope-metastore:/data-metastore
     networks:
       - app-network
 
   grafana:
+    # CCX3 (L3 18-23,42-47): monitoramento longe do caminho crítico. O bloco cedeu
+    # 18 ao redis-vendor, 19-20 ao vendor e 21 ao client, e ficou com 22-23.
+    cpuset: "22-23"
     image: grafana/grafana:latest
     ports:
       - 3000:3000
@@ -103,7 +159,7 @@ services:
       - prometheus
       - pyroscope
     volumes:
-      - grafana_data:/var/lib/grafana
+      - ./.data/grafana:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
       - ./grafana/dashboards:/etc/grafana/dashboards
     environment:
@@ -114,6 +170,9 @@ services:
       - app-network
 
   alloy:
+    # CCX3 (L3 18-23,42-47): monitoramento longe do caminho crítico. O bloco cedeu
+    # 18 ao redis-vendor, 19-20 ao vendor e 21 ao client, e ficou com 22-23.
+    cpuset: "22-23"
     image: grafana/alloy:latest
     volumes:
       - ./alloy.config:/etc/alloy/alloy.config:ro
@@ -129,6 +188,10 @@ services:
       - app-network
 
   cadvisor:
+    # CCX3 (L3 18-23,42-47): cadvisor é o vizinho mais barulhento; longe do vendor.
+    # Sobrou 22-23 depois que o bloco cedeu 18 ao redis-vendor, 19-20 ao vendor e
+    # 21 ao client.
+    cpuset: "22-23"
     image: gcr.io/cadvisor/cadvisor:latest
     ports:
       - 8080:8080
@@ -144,11 +207,14 @@ services:
       - app-network
 
   prometheus:
+    # CCX3 (L3 18-23,42-47): monitoramento longe do caminho crítico. O bloco cedeu
+    # 18 ao redis-vendor, 19-20 ao vendor e 21 ao client, e ficou com 22-23.
+    cpuset: "22-23"
     image: prom/prometheus:latest
     container_name: prometheus
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
+      - ./.data/prometheus:/prometheus
     ports:
       - "9090:9090"
     networks:
@@ -158,8 +224,6 @@ networks:
   app-network:
 
 volumes:
-  redis_vendor_data:
-  redis_issuer_data:
-  pyroscope_data:
-  grafana_data:
-  prometheus_data:
+  pyroscope-data:
+  pyroscope-compactor:
+  pyroscope-metastore:

--- a/docs/worker-affinity-and-saturation.md
+++ b/docs/worker-affinity-and-saturation.md
@@ -1,0 +1,473 @@
+# Worker Affinity and the Saturation Layout
+
+How a client is bound to a single vendor worker, why that binding had to be made
+explicit, and what it exposed underneath. Every number here was measured on the
+bench box with `run_tps_saturation_sweep.sh` at a target of 8192 or 16384 TPS
+across the five payment modes, or with a single-mode run instrumented directly.
+The core layout itself is described in [`tuning.md`](../tuning.md); this document
+covers the change and the evidence behind it.
+
+The starting question was how to make a client's HTTP traffic always reach the
+same worker. Answering it moved the measured ceiling from ~3900 to 9.0-10.4k TPS
+on four of the five modes, because the mechanism that provides affinity is also
+the mechanism that distributes load, and it was distributing it badly.
+
+Read this document for the mechanisms and the evidence. For where the system ends
+up — which component holds each mode, what a payment costs, and what the two
+remaining barriers require — read
+[benchmark-ceiling-and-what-remains.md](benchmark-ceiling-and-what-remains.md).
+
+---
+
+## 1. A connection already belongs to one worker
+
+**Mechanism:** each Uvicorn worker accepts its own connections and serves every
+request on a connection in its own event loop. HTTP keep-alive therefore *is*
+worker affinity, and the vendor holds idle connections for 120s
+(`KEEP_ALIVE_TIMEOUT_SEC` in `src/nanomoni/main.py`). Nothing needs to be added
+at the server for a *connection* to stay on a worker.
+
+**What defeated it:** `run_client_flow` created one `VendorClientAsync` per
+process and shared it across every virtual client in that process. Its
+`aiohttp.ClientSession` pool is keyed by host, not by caller, so a virtual client
+about to send its next payment took whichever connection was free. Consecutive
+payments on the same channel left over different connections, i.e. reached
+different workers.
+
+**Change:** one dedicated `VendorClientAsync` per virtual client, its pool capped
+at a single connection (`connection_limit=1` →
+`aiohttp.TCPConnector(limit=1, keepalive_timeout=120)` in
+`src/nanomoni/infrastructure/http/http_client.py`). The keep-alive value mirrors
+the server's on purpose: aiohttp's 15s default would drop an idle connection and
+the reconnect would be accepted by whatever worker won the race, silently undoing
+the affinity.
+
+**Verification:** a 60s payword run with 20 virtual clients, sampling every 5s
+which worker held which connection (`scripts/probe-worker-connections.py`):
+**0 of the connections changed worker.** The 23 connections seen at the start are
+20 dedicated ones plus one bootstrap connection per client process (used only to
+fetch the vendor public key); the bootstrap ones drop out after aiohttp's default
+15s idle, leaving exactly 20.
+
+---
+
+## 2. A shared accept socket does not balance
+
+**What the affinity exposed:** with each client pinned to the worker that
+accepted it, *which* worker accepted it started to matter. Uvicorn's multi-worker
+mode has all workers accept from one shared listening socket and lets the kernel
+pick, and that is not round-robin — the worker quickest to accept keeps winning,
+so a burst of connections piles onto a few of them.
+
+Measured under `paytree` with 40 virtual clients and 10 workers, one core each:
+
+| core | connections | worker CPU |
+|---|---|---|
+| 10 | 7 | 91% |
+| 9 | 7 | 90% |
+| 6 | 6 | 89% |
+| 8 | 5 | 84% |
+| 7 | 4 | 71% |
+| 2 | 4 | 67% |
+| 5 | 3 | 57% |
+| 4 | 2 | 18% |
+| 1 | 1 | 9% |
+| 3 | 1 | 8% |
+
+Seven workers were at or near the ceiling of their single core while two sat
+below 10%. The aggregate hid it completely: cadvisor reported 5.5 of 10 cores,
+which reads as "half idle" and is really "some workers saturated, some idle".
+This is why doubling the virtual clients from 20 to 40 moved `paytree` by 0.1% —
+the new clients piled onto the same skewed distribution. In the 20-client run the
+spread was worse still: 20 connections on 5 of the 10 workers.
+
+**Change:** one listening socket per worker. `src/nanomoni/main.py` runs
+`VENDOR_API_WORKERS` single-worker servers on consecutive ports from
+`VENDOR_API_PORT` (8000..8009) instead of Uvicorn's shared-socket mode, each
+pinned to its own core by the existing `VENDOR_PIN_WORKERS_TO_CORES`; a worker
+dying takes the set down, since a container missing one port would silently drop
+the traffic aimed at it. The generator picks its port from its own identity:
+`vendor_url_for_worker(base_url, index, port_count)` in
+`src/nanomoni/client/common.py`, using the client's *global* index in
+`CLIENT_PRIVATE_KEY_PEMS` so that several client processes each taking a slice
+still add up to an even spread.
+
+**Verification:** the same 40-client `paytree` run afterwards: exactly **4
+connections per worker** (5 on port 8000, which also serves Prometheus), every
+worker between **81% and 91%**, summing to **8.59 of 10 cores** against 5.85
+before.
+
+---
+
+## 3. Redis was spending its core on AOF rewrite, not on payments
+
+**Per-payment cost.** The payment path is already tight: 2 round-trips, one
+`MGET` for the channel and its state or nodes, then one `EVALSHA` whose Lua
+script performs every write atomically (see
+`src/nanomoni/infrastructure/scripts.py`). Measured on `paytree_child_pair` from
+`INFO commandstats`, at 4733 payments/s on an accumulated keyspace:
+
+| command | per payment | µs/call |
+|---|---|---|
+| `MGET` | 1 | 3.1 |
+| `EVALSHA` | 1 | 76.9 |
+| `SET` (inside the script) | 5 | 1.9 |
+| `ZADD` (inside the script) | 2 | 6.0 |
+| `GET` (inside the script) | 1 | 1.0 |
+
+The inner calls are *included* in the `EVALSHA` figure, and account for ~23 µs of
+its 77 µs; the rest is script-level work. Adding what Redis spends outside
+command execution gives ~105 µs of process CPU per payment.
+
+**The discrepancy.** cadvisor showed the `redis-vendor` cgroup at 0.86-0.96 of
+its single core, which is what first suggested Redis as the next ceiling. But
+`INFO` reported the `redis-server` process using only 0.49 core. Listing
+processes by core during a run resolved it: **two `redis-server` processes on
+core 11**, ~0.5 core each, the second one present only while the run was in
+flight. It is the AOF rewrite child — a `fork`, so it inherits the cgroup and
+therefore the same single core, competing head to head with the one thread that
+serves payments. Core 11 was pegged at 100% (63% user, 23% system, 14% softirq).
+
+**Why it never stopped rewriting.** Nothing deletes keys after a run, so the
+keyspace had grown to 15.3M keys and 3.89 GB across runs, with the AOF at 3.45 GB
+over a base of 1.97 GB. With `auto-aof-rewrite-percentage` at its default a
+rewrite fires every time the file doubles, so under load it was almost always
+running. The accumulation cost more than the rewrites: on an empty keyspace the
+same `EVALSHA` takes **36 µs instead of 72**.
+
+**Change:** `redis-vendor` gets a second core (`cpuset: "11,18"`), taken from the
+monitoring block (now `19-23`) rather than from the vendor or the generator,
+which are in the measured path — and landing in another L3 is desirable, since
+the rewrite streams the whole dataset and would otherwise evict the serving
+thread's cache. `run_tps_saturation_sweep.sh` flushes both datastores before
+every run, so no mode inherits the keyspace of the modes before it.
+
+**Verification:** `paytree_child_pair` at **8120 payments/s** (was 4733), the
+rewrite child on core 18 at 35%, core 11 down to 84%, and the serving process
+holding 0.85 core instead of 0.49.
+
+One operational note: an AOF that size also costs ~60s of container startup
+before Redis will answer, which is worth knowing when a restart looks hung.
+
+---
+
+## 4. What the sweep measured at each step
+
+Achieved TPS against a target of 8192, five modes:
+
+| mode | baseline (16 clients, shared pool and socket) | 40 clients, shared socket | 40 clients, port per worker | + 2-core Redis and per-run flush |
+|---|---|---|---|---|
+| payword | 3919.0 | 5321.9 | 7247.0 | **8150.9** (99.5%) |
+| paytree | 3840.5 | 5380.2 | 6837.9 | **8117.0** (99.1%) |
+| paytree_first_opt | 3308.6 | 5212.3 | 6542.7 | **8038.2** (98.1%) |
+| paytree_child_pair | 3847.4 | 4802.8 | 5293.3 | **8027.2** (98.0%) |
+| signature | 2111.7 | 4424.2 | 5767.0 | 6271.2 (76.6%) |
+
+The baseline column comes from the sweep that preceded this work; several things
+differ in it besides the connection handling (virtual-client count and core
+layout among them), so it marks where the measurement started rather than
+isolating one change. The last two columns differ only in the Redis changes.
+
+---
+
+## 5. Configuration surface
+
+| Variable | Where | Meaning |
+|---|---|---|
+| `VENDOR_API_WORKERS` | `envs/vendor.env.sh` | Number of single-worker servers, and therefore of ports used from `VENDOR_API_PORT` upward |
+| `VENDOR_PIN_WORKERS_TO_CORES` | `envs/vendor.env.sh` | Each worker claims one core of the container `cpuset` for its lifetime |
+| `CLIENT_PROCESSES` | `envs/client.env.sh` | Client processes to split the virtual clients over |
+| `CLIENT_PIN_PROCESSES_TO_CORES` | `envs/client.env.sh` | Same core-claiming for the generator's processes |
+| `CLIENT_VENDOR_PORT_COUNT` | `envs/client.env.sh` | Consecutive vendor ports to spread virtual clients over; `1` disables spreading |
+
+Three invariants hold this together, and breaking any of them degrades quietly
+rather than failing:
+
+- `CLIENT_VENDOR_PORT_COUNT` must equal `VENDOR_API_WORKERS`, or some workers
+  receive no traffic.
+- `CLIENT_VIRTUAL_CLIENTS` should be a multiple of it, or some workers carry an
+  extra client and cap the measured ceiling.
+- The `cpuset` must hold at least `VENDOR_API_WORKERS` cores; surplus workers are
+  left unpinned rather than doubled up, and the startup log says which core each
+  worker took.
+
+On the host, only port 8000 is published. The rest of the range would collide
+with the issuer on 8001 and the client's metrics on 8002, and nothing needs them
+from outside: the generator dials `vendor:800N` over the compose network, and
+Prometheus keeps scraping `:8000`, where `/metrics` aggregates every worker
+through `PROMETHEUS_MULTIPROC_DIR`. The same collision applies to running the
+vendor directly on the host, which is why the local-dev and example env scripts
+keep `VENDOR_API_WORKERS=1`.
+
+---
+
+## 6. The ceiling at a target of 16384
+
+Four of the five modes finished within 2% of the 8192 target, so the target held
+them rather than the system. Raising `TPS_VALUES` to 16384 located the knee:
+
+| mode | achieved TPS | ratio of target |
+|---|---|---|
+| payword | 10368.4 | 63.3% |
+| paytree | 9267.7 | 56.6% |
+| paytree_child_pair | 9159.6 | 55.9% |
+| paytree_first_opt | 9009.6 | 55.0% |
+| signature | 6219.5 | 38.0% |
+
+`signature` went from 6271 to 6219 when the target doubled. The generator binds
+it (2.56 of the client's 3 cores against 3.52 of the vendor's 10), so the target
+does not reach it — the failure mode that the 3:1 vendor-to-client core rule in
+`tuning.md` exists to prevent.
+
+A `paytree_first_opt` run instrumented during its plateau gives the shape of the
+ceiling for the other four:
+
+| component | CPU | against its cpuset |
+|---|---|---|
+| vendor, 10 workers | 9.80 cores | 98% on each of 10 |
+| client, 3 processes | 2.79 cores | 93% of 3 |
+| redis-vendor | 1.15 cores | 58% of 2 |
+
+Each worker held 4 connections, except port 8000 with 5, which also serves
+Prometheus. The vendor spends 1.02 ms of CPU per payment, the generator 291 µs,
+Redis 120 µs across its two cores. Latency during the same window: p50 2.4 ms,
+p95 3.3 ms, p99 4.9 ms, 23 payments in flight.
+
+A p99 of 4.9 ms at 98% CPU puts this at a throughput ceiling rather than at a
+queue collapse, and the distribution matches what section 2 set out to produce.
+The generator trails the vendor by 5 points, so a core given to one side without
+the other moves the binding component instead of the ceiling.
+
+---
+
+## 7. Five walls, and where each one lives
+
+Every ceiling in this document announced itself through one signal — an aggregate
+near its limit — and the cause differed each time.
+
+| # | ceiling | reading at the time | cause |
+|---|---|---|---|
+| 0 | 3900 | server capacity | the shared `aiohttp` pool spread one channel's payments over several workers |
+| 1 | 5300 | vendor at 5.5 of 10 cores, half idle | shared accept socket: 7 workers at the ceiling of their core, 2 under 10% |
+| 2 | 5300-6800 | `redis-vendor` at 0.96 of one core, single-threaded | the serving thread used 0.49; the AOF rewrite child took the rest of the core, and the keyspace left by earlier runs moved `EVALSHA` from 36 to 72 µs |
+| 3 | 8100 | system capacity | `TPS_VALUES=8192`, with four modes delivering 98-99.5% of it |
+| 4 | 9000-10400 | vendor saturated again | the vendor saturates: 10 cores at 98%, 1.02 ms of CPU per payment |
+
+Walls 0 and 1 hold load away from capacity that exists. Wall 2 spends
+capacity on work outside the measured path — the rewrite child burns a core on
+the keyspace that earlier runs left behind. Wall 3 comes from a constant in a
+shell script. Wall 4 reports the cost of a payment.
+
+So four of the five describe the harness, and `signature` at 6219 joins them,
+since it measures the generator. Walls 1 and 2 also share a mechanism: a cgroup
+total hides the distribution inside it, and in both cases the container sat at
+its limit while the process doing the work did not. Doubling the virtual clients
+from 20 to 40 moved `paytree` by 0.1% (section 2) — the intervention followed the
+aggregate and missed the cause. Section 11 lists the commands that open the
+aggregate up, per worker, per command and per core.
+
+---
+
+## 8. Two loops, and what ends each one
+
+Removing interference forms the first loop. Walls 0, 1 and 2 changed which
+hardware paid for a payment, or removed a cost that the design does not impose —
+the 72 µs `EVALSHA` of section 3 returns to 36 µs on a keyspace that holds one
+run. Neither kind touches what the design itself costs. That loop carried the
+ceiling from 3900 to 8100 on the same 24 cores, each fix holds for every run
+after it, and the loop terminates: the defects run out, and what the ceiling
+reports then is the cost of the design.
+
+Buying cores forms the second loop. It leaves the cost per payment where it is
+and raises the ceiling by widening a cpuset. On a fixed box it takes from a
+neighbour, and the 3:1 rule couples the two sides: a core for the vendor draws
+1.33 cores, because the generator grows with it or binds first. This loop ran
+once, when `redis-vendor` took core 18 from the monitoring block, and that round
+mixed both loops — the core was a purchase, the per-run `flushall` removed
+interference, and the jump from 4733 to 8120 on `paytree_child_pair` covers the
+two together.
+
+The monitoring block holds 5 cores and uses 0.1 of them. Spending all 5 puts the
+vendor at 14 cores and the generator at 4, which the per-payment costs in section
+6 turn into 13.7k TPS on either side. The serving thread of `redis-vendor` caps
+that number: one thread executes every command, a payment costs it ~105 µs, and
+the four paytree and payword modes run between 9.0k and 10.4k. These two
+figures come from arithmetic over the measurements above; no run has held 14
+vendor cores.
+
+The second loop therefore has one round left, and the wall behind it takes no
+cores. What follows it changes the design: the round-trip count per payment, the
+writes the script performs, or a keyspace shard that removes the single serving
+thread. Reporting CPU per payment instead of TPS also ends the loop, by stating a
+number that the size of the box does not set. Section 9 spends part of that round
+and reports which of these the ceiling turns out to follow.
+
+---
+
+## 9. Spending the round: 12 vendor cores and 4 generator cores
+
+Section 8 projects that the serving thread of `redis-vendor` caps the next round
+of core buying. Spending 3 of the monitoring block's 5 cores tests it. The vendor
+moved from `1-10` to `1-10,19-20` with `VENDOR_API_WORKERS=12`, the generator from
+`12-14` to `12-14,21` with `CLIENT_PROCESSES=4`, `CLIENT_VENDOR_PORT_COUNT=12` and
+48 virtual clients, so the 3:1 rule holds at 12:4 and every worker takes 4
+clients. Monitoring kept `22-23`. Cores 19-20 belong to another L3 than `1-10`,
+which the workers absorb: each one is a process with its own connection and its
+own working set.
+
+The same sweep at the same target of 16384:
+
+| mode | 10 vendor / 3 generator | 12 vendor / 4 generator | change |
+|---|---|---|---|
+| payword | 10368.4 | 12557.6 | +21% |
+| paytree | 9267.7 | 11688.5 | +26% |
+| paytree_first_opt | 9009.6 | 9761.4 | +8% |
+| paytree_child_pair | 9159.6 | 9672.9 | +6% |
+| signature | 6219.5 | 7806.6 | +26% |
+
+`scripts/probe-saturation.py` sampled each plateau for what holds it:
+
+| mode | plateau TPS | vendor | generator | redis serving thread | redis µs/payment |
+|---|---|---|---|---|---|
+| payword | 12753 | 11.85/12 | 3.56/4 | 0.96 | 75 |
+| paytree | 11909 | 7.74/12 | 2.51/4 | 0.91 | 76 |
+| paytree_child_pair | 10020 | 10.10/12 | 2.86/4 | 1.01 | 100 |
+| paytree_first_opt | 9299 | 10.48/12 | 2.98/4 | 0.98 | 106 |
+| signature | 8190 | 11.97/12 | 2.27/4 | 0.20 | 65 |
+
+The projection holds for the four paytree and payword modes. The serving thread
+runs between 0.91 and 1.01 of the one core it can use, and each ceiling sits at
+the inverse of what a payment costs it: 75 µs allows 13.3k and payword reached
+12.6k, 106 µs allows 9.4k and first_opt reached 9.8k. Two extra vendor cores moved
+first_opt by 8% and child_pair by 6% while the vendor left 12-16% of its cores
+unused, which is how a component that takes no cores reads from outside.
+
+What the script writes explains the order of the modes. `paytree` and `payword`
+issue 3 `SET`s per payment and their `EVALSHA` costs 24 µs; `paytree_child_pair`
+and `paytree_first_opt` issue 5 `SET`s and 2 `ZADD`s, and their `EVALSHA` costs 37
+and 43 µs. The ranking the sweep reports per scheme therefore reduces to the
+number of keys that scheme's script writes.
+
+`signature` moved for the other reason. The vendor holds 11.97 of 12 cores while
+Redis stays at 0.20, so verifying a signature is what limits it, and the 2 cores
+went to the component that was short. Section 6 records 3.52 of 10 vendor cores at
+6271 TPS for this mode, which is 561 µs per payment against the 1533 µs measured
+here. Three sources agree on the figure measured here — `mpstat` per core, the
+in-container probe, and cadvisor — and the earlier one does not reproduce.
+
+Latency separates the two situations. payword spreads its work over three
+components at 89-99% and holds p99 at 2.9 ms. first_opt funnels through one thread
+at 0.98 and sits at p50 3.5 ms with p99 11.9 ms: the queue in front of a component
+that runs one command at a time.
+
+One entry in section 8 needs correcting against this: the remaining monitoring
+cores buy nothing for `paytree_first_opt` and `paytree_child_pair`, so the second
+loop has less runway than the core arithmetic offers, and for those two it ended
+here. A second figure to drop is the 11 KB per payment once attributed to
+first_opt, which came from a window where its `MGET` cost 68 µs; on these plateaus
+that `MGET` costs 2.5 µs, and the write count above carries the difference between
+the modes instead.
+
+---
+
+## 10. Where the vendor spends its own CPU
+
+Section 9 leaves the vendor holding 11.97 of 12 cores in `signature` and 10.0 to
+10.5 in the other four modes, so the cost of a payment inside the vendor bounds
+what relieving Redis can buy. The plotter already measures this: `profiling/
+aggregate.py` reads the merged Pyroscope profile over each run's plateau and writes
+`profile_macro_micro_table.csv` — the vendor's total CPU, the part under that mode's
+endpoint handler, and the crypto and Redis parts inside the handler — plus one flame
+graph per mode. The saturation report runs that same stage now, so a sweep aimed at
+a ceiling produces the attribution of that ceiling in the same directory.
+
+Shares of the vendor's total CPU, from the run in section 9:
+
+| mode | above the handler | inside it | crypto | redis | unattributed inside |
+|---|---|---|---|---|---|
+| paytree | 55.4% | 44.6% | 7.6% | 29.7% | 6.9% |
+| paytree_child_pair | 57.6% | 42.4% | 1.8% | 27.3% | 12.6% |
+| paytree_first_opt | 56.6% | 43.4% | 2.3% | 26.7% | 13.7% |
+| payword | 58.6% | 41.4% | 1.8% | 31.4% | 7.6% |
+| signature | 54.4% | 45.6% | 19.9% | 19.2% | 6.3% |
+
+Above the handler sits the ASGI path: HTTP parsing, routing, dependency
+resolution, response serialization, the event loop. It takes more CPU than the
+Redis calls in every mode, and more than signature verification in the mode that
+verifies signatures. So the framework sets the floor for four of the five schemes,
+and the two cores section 9 moved to the vendor spent over half of themselves
+there.
+
+The flame graphs name what fills that path. The widest frames by self time are
+CPython's own — `_PyEval_EvalFrameDefault`, `_PyFunction_Vectorcall`,
+`_PyType_Lookup` — both above the handler and inside it, which is also what the
+unattributed column above is made of. The vendor runs Python 3.9 (`pyproject.toml`
+pins `>=3.9,<3.10.0`), so the specializing interpreter of 3.11 and later has never
+been under this measurement.
+
+---
+
+## 11. Reproducing the measurements
+
+One snapshot that attributes a plateau — rate, latency, CPU per payment per
+container, the Redis serving thread against its one-core ceiling, and the command
+split inside it:
+
+```sh
+poetry run python scripts/probe-saturation.py 12   # 12s window
+```
+
+It resets `commandstats`, so run it while traffic is steady: a window that spans
+the start or end of a run mixes the ramp into every average. It also detects the
+mode from the counter that is moving, which spares one trap — the counter names do
+not follow the mode names. `paytree` increments `paytree_std_payment_requests_total`
+and `signature` increments the unprefixed `payment_requests_total`, so a query
+written from the mode name returns an empty result and reads as an idle system.
+
+The pieces it is built from, for when only one of them is needed.
+
+Per-worker connections and CPU — the split cadvisor's container total hides:
+
+```sh
+docker cp scripts/probe-worker-connections.py nanomoni-vendor-1:/tmp/probe.py
+docker exec nanomoni-vendor-1 python /tmp/probe.py 6   # 6s CPU window
+```
+
+Redis command accounting, around a steady-state window of a running benchmark:
+
+```sh
+docker exec nanomoni-redis-vendor-1 redis-cli config resetstat
+sleep 40
+docker exec nanomoni-redis-vendor-1 redis-cli info commandstats
+docker exec nanomoni-redis-vendor-1 redis-cli info stats   # used_cpu_user/sys, net bytes
+```
+
+Remember that a command called from Lua is counted in `commandstats` on its own
+*and* inside the `EVALSHA` that called it, so the two cannot be added.
+
+Per-core utilization and per-process CPU, from `sysstat`:
+
+```sh
+mpstat -P 1-14,18-21 5 1   # %usr / %sys / %soft per core
+pidstat -p ALL 5 1         # which process is burning which core
+```
+
+The charts, the ceiling per mode, and the CPU attribution of section 10, from a
+sweep's timing file:
+
+```sh
+poetry run python -m bench_plotter.saturation tps_saturation_timing.json
+```
+
+Per-container CPU, from cadvisor through Prometheus:
+
+```sh
+curl -sg "http://localhost:9090/api/v1/query" --data-urlencode \
+  'query=sum by (container_label_com_docker_compose_service) (rate(container_cpu_usage_seconds_total{job="cadvisor",image!=""}[1m]))'
+```
+
+Dividing the CPU of a container by the rate gives the per-payment cost that
+sections 8 and 9 reason from, and it holds across machine sizes where TPS does
+not. Cross-check any container reading that decides something: `docker stats
+--no-stream` reported the vendor at 6.6% of one core during the section 9 runs
+while `mpstat`, the in-container probe and cadvisor all put it above 11 cores.

--- a/envs/example.client.sh
+++ b/envs/example.client.sh
@@ -29,9 +29,9 @@ export CLIENT_PIN_PROCESSES_TO_CORES="false"
 # VENDOR_BASE_URL.
 export CLIENT_VENDOR_PORT_COUNT=1
 
-# Client private keys (PEM format), one per virtual client, dynamically
-# generated as a JSON array (unless already provided). CLIENT_PAYMENT_COUNT
-# and CLIENT_TARGET_TPS below are split evenly across them; CLIENT_PAYMENT_COUNT
+# Client private keys (PEM format), one per virtual client, freshly generated
+# every time this script runs, as a JSON array. CLIENT_PAYMENT_COUNT and
+# CLIENT_TARGET_TPS below are split evenly across them; CLIENT_PAYMENT_COUNT
 # must be divisible by CLIENT_VIRTUAL_CLIENTS.
 _client_keys_json="[]"
 for _ in $(seq 1 "$CLIENT_VIRTUAL_CLIENTS"); do

--- a/envs/example.client.sh
+++ b/envs/example.client.sh
@@ -8,8 +8,38 @@ export ISSUER_BASE_URL="http://issuer:8001/api/v1"
 # export VENDOR_BASE_URL="http://localhost:8000/api/v1"
 # export ISSUER_BASE_URL="http://localhost:8001/api/v1"
 
-# Client private key (PEM format) dynamically generated (unless already provided)
-export CLIENT_PRIVATE_KEY_PEM="$(openssl ecparam -genkey -name secp256k1 | openssl pkcs8 -topk8 -nocrypt)"
+# Number of independent virtual clients (own keypair + channel + payment loop)
+# the runner drives concurrently in-process via asyncio.gather. Only controls
+# how many keys are generated below -- the runner derives its client count
+# from len(CLIENT_PRIVATE_KEY_PEMS), not from this variable directly.
+CLIENT_VIRTUAL_CLIENTS="${CLIENT_VIRTUAL_CLIENTS:-1}"
+
+# OS processes the virtual clients above are dealt across (round-robin). One
+# event loop saturates one core, so this -- not CLIENT_VIRTUAL_CLIENTS -- is what
+# lets the generator use more than one core. Keep it equal to the number of cores
+# in the client's cpuset in docker-compose.yml.
+export CLIENT_PROCESSES=1
+
+# Fix each of those processes to one core of the cpuset (1:1). Leave "false"
+# outside benchmarks.
+export CLIENT_PIN_PROCESSES_TO_CORES="false"
+
+# Consecutive vendor ports to spread virtual clients over, one per vendor worker
+# (keep equal to VENDOR_API_WORKERS). 1 sends everything to the port in
+# VENDOR_BASE_URL.
+export CLIENT_VENDOR_PORT_COUNT=1
+
+# Client private keys (PEM format), one per virtual client, dynamically
+# generated as a JSON array (unless already provided). CLIENT_PAYMENT_COUNT
+# and CLIENT_TARGET_TPS below are split evenly across them; CLIENT_PAYMENT_COUNT
+# must be divisible by CLIENT_VIRTUAL_CLIENTS.
+_client_keys_json="[]"
+for _ in $(seq 1 "$CLIENT_VIRTUAL_CLIENTS"); do
+  _pem="$(openssl ecparam -genkey -name secp256k1 | openssl pkcs8 -topk8 -nocrypt)"
+  _client_keys_json="$(jq -n --argjson arr "$_client_keys_json" --arg pem "$_pem" '$arr + [$pem]')"
+done
+export CLIENT_PRIVATE_KEY_PEMS="$_client_keys_json"
+unset _client_keys_json _pem
 
 export CLIENT_PAYMENT_COUNT=5000
 

--- a/envs/example.vendor.sh
+++ b/envs/example.vendor.sh
@@ -14,7 +14,16 @@ export VENDOR_API_HOST="0.0.0.0"
 export VENDOR_API_PORT="8000"
 export VENDOR_API_DEBUG="false"
 export VENDOR_API_CORS_ORIGINS="*"
+# Each worker is its own single-worker server on its own port, counting up from
+# VENDOR_API_PORT (N workers occupy PORT..PORT+N-1). Keep this at 1 outside the
+# benchmark: on the host, 8001 and 8002 already belong to the issuer and to the
+# client's metrics. The client's CLIENT_VENDOR_PORT_COUNT must match this value.
 export VENDOR_API_WORKERS="1"
+
+# Pin each Uvicorn worker to a single core of the container's cpuset, so the
+# kernel cannot migrate it mid-run. Needs a cpuset with at least
+# VENDOR_API_WORKERS cores; leave "false" outside benchmarks.
+export VENDOR_PIN_WORKERS_TO_CORES="false"
 
 # Prometheus multiprocess metrics directory (must be writable by the app)
 export PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_vendor"

--- a/envs/vendor.env.dev.sh
+++ b/envs/vendor.env.dev.sh
@@ -19,6 +19,10 @@ export VENDOR_API_DEBUG="true"
 export VENDOR_API_CORS_ORIGINS="*"
 export VENDOR_API_WORKERS="1"
 
+# Off for local dev: with no cpuset the single worker would be pinned to an
+# arbitrary core of the whole machine.
+export VENDOR_PIN_WORKERS_TO_CORES="false"
+
 # Prometheus (dev throwaway path — metrics not collected locally)
 export PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_vendor_dev"
 

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -4,8 +4,17 @@ IFS=$'\n\t'
 
 # Target TPS sweep. For each TPS the client sends (TPS * RUN_DURATION_SEC)
 # payments paced at 1/TPS, yielding ~RUN_DURATION_SEC seconds of traffic.
-TPS_VALUES=(16 32 64 128 256)
+TPS_VALUES=(8 16 32 64 128 256 512 1024 2048 4096)
 RUN_DURATION_SEC=600
+
+# One virtual client per this many target TPS (own keypair + channel + payment
+# loop each, see CLIENT_VIRTUAL_CLIENTS in envs/client.env.sh). A single
+# sequential client's ceiling is 1/round_trip_latency (see
+# run_tps_saturation_sweep.sh), so without fanning out, high-TPS iterations
+# would silently fall short of their target instead of measuring it. Floored
+# at 1 client when TPS < TPS_PER_CLIENT. TPS_VALUES at/above TPS_PER_CLIENT
+# should stay multiples of this so fan-out divides evenly.
+TPS_PER_CLIENT=256
 
 export SLEEP_TIME=30
 export SLEEP_GAP=30
@@ -16,9 +25,11 @@ export DRAIN_TIME=180
 # Timestamp of this server-side benchmark execution (root folder for plots).
 RUN_TS="$(date '+%Y%m%d_%H%M%S')"
 
-# Current TPS/count for the active sweep iteration (set inside the loop).
+# Current TPS/count/client-fanout for the active sweep iteration (set inside
+# the loop).
 BENCHMARK_TARGET_TPS=0
 BENCHMARK_COUNT_VAR=0
+BENCHMARK_VIRTUAL_CLIENTS=0
 
 # Per-mode timing entries, joined into the timing JSON at the end.
 TIMING_ENTRIES=()
@@ -42,7 +53,7 @@ run_mode() {
   # source) makes this benchmark's target win over the env file's value.
   export CLIENT_TARGET_TPS=$BENCHMARK_TARGET_TPS
 
-  log "=== [$mode] starting benchmark run (tps=$BENCHMARK_TARGET_TPS, count=$BENCHMARK_COUNT_VAR) ==="
+  log "=== [$mode] starting benchmark run (tps=$BENCHMARK_TARGET_TPS, count=$BENCHMARK_COUNT_VAR, clients=$BENCHMARK_VIRTUAL_CLIENTS) ==="
 
   log "[$mode] pre-run gap: sleeping ${SLEEP_GAP}s"
   sleep "$SLEEP_GAP"
@@ -64,13 +75,22 @@ run_mode() {
   sleep "$DRAIN_TIME"
   end=$(date +%s%3N)
 
+  # Nothing deletes channels, states or merkle nodes during a run, so without
+  # this every later run inherits every earlier one: more memory, and an AOF
+  # whose rewrites grow with the accumulated dataset while traffic is in flight.
+  # That penalty lands on whichever mode happens to run last, which is not a
+  # property of the mode. Done after the window closes so the reclaim (and the
+  # rewrite it triggers) is not measured as part of this run.
+  log "[$mode] flushing vendor datastore"
+  docker compose exec -T redis-vendor redis-cli flushall >/dev/null || true
+
   local result="success"
   if [ "$status" -ne 0 ]; then
     result="failed"
     OVERALL_STATUS=1
   fi
   log "=== [$mode] finished: $result (window ${start}ms -> ${end}ms) ==="
-  TIMING_ENTRIES+=("{\"mode\":\"$mode\",\"tps\":$BENCHMARK_TARGET_TPS,\"total_requests\":$BENCHMARK_COUNT_VAR,\"status\":\"$result\",\"prometheus_timestamps\":{\"start_ms\":$start,\"finish_ms\":$end}}")
+  TIMING_ENTRIES+=("{\"mode\":\"$mode\",\"tps\":$BENCHMARK_TARGET_TPS,\"total_requests\":$BENCHMARK_COUNT_VAR,\"virtual_clients\":$BENCHMARK_VIRTUAL_CLIENTS,\"status\":\"$result\",\"prometheus_timestamps\":{\"start_ms\":$start,\"finish_ms\":$end}}")
 }
 
 run_signature() {
@@ -84,7 +104,9 @@ run_paytree() {
   source envs/client.env.sh
   export CLIENT_PAYMENT_MODE="paytree"
   export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
-  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  # Each virtual client opens its own channel, so the cap sizes ONE client's
+  # tree, not the sweep-wide count (see run_tps_saturation_sweep.sh).
+  export CLIENT_PAYTREE_MAX_I=$((BENCHMARK_COUNT_VAR / BENCHMARK_VIRTUAL_CLIENTS))
   # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
   export CLIENT_CHANNEL_AMOUNT=10000000
   run_mode "paytree"
@@ -94,7 +116,7 @@ run_paytree_first_opt() {
   source envs/client.env.sh
   export CLIENT_PAYMENT_MODE="paytree_first_opt"
   export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
-  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$((BENCHMARK_COUNT_VAR / BENCHMARK_VIRTUAL_CLIENTS))
   # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
   export CLIENT_CHANNEL_AMOUNT=10000000
   run_mode "paytree_first_opt"
@@ -104,7 +126,7 @@ run_paytree_child_pair() {
   source envs/client.env.sh
   export CLIENT_PAYMENT_MODE="paytree_child_pair"
   export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
-  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$((BENCHMARK_COUNT_VAR / BENCHMARK_VIRTUAL_CLIENTS))
   # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
   export CLIENT_CHANNEL_AMOUNT=10000000
   run_mode "paytree_child_pair"
@@ -114,7 +136,7 @@ run_payword() {
   source envs/client.env.sh
   export CLIENT_PAYMENT_MODE="payword"
   export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
-  export CLIENT_PAYWORD_MAX_K=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYWORD_MAX_K=$((BENCHMARK_COUNT_VAR / BENCHMARK_VIRTUAL_CLIENTS))
   # Ensure channel_amount >= (max_k * unit_value) with headroom for remainder.
   export CLIENT_CHANNEL_AMOUNT=10000000
   run_mode "payword"
@@ -129,7 +151,16 @@ log "Server run timestamp: $RUN_TS"
 for tps in "${TPS_VALUES[@]}"; do
   BENCHMARK_TARGET_TPS=$tps
   BENCHMARK_COUNT_VAR=$((tps * RUN_DURATION_SEC))
-  log "=== Sweep iteration: tps=$BENCHMARK_TARGET_TPS count=$BENCHMARK_COUNT_VAR ==="
+  # Floor at 1 so TPS below TPS_PER_CLIENT still generates a keypair instead of
+  # an empty CLIENT_PRIVATE_KEY_PEMS (which the client rejects at startup).
+  BENCHMARK_VIRTUAL_CLIENTS=$((tps / TPS_PER_CLIENT))
+  if [ "$BENCHMARK_VIRTUAL_CLIENTS" -lt 1 ]; then
+    BENCHMARK_VIRTUAL_CLIENTS=1
+  fi
+  # Read by envs/client.env.sh (sourced inside each run_<mode> below) to size
+  # CLIENT_PRIVATE_KEY_PEMS -- must be exported before that source call.
+  export CLIENT_VIRTUAL_CLIENTS=$BENCHMARK_VIRTUAL_CLIENTS
+  log "=== Sweep iteration: tps=$BENCHMARK_TARGET_TPS count=$BENCHMARK_COUNT_VAR clients=$BENCHMARK_VIRTUAL_CLIENTS ==="
 
   run_signature
   sleep "$SLEEP_TIME"

--- a/scripts/client-entrypoint.sh
+++ b/scripts/client-entrypoint.sh
@@ -11,7 +11,7 @@ required_env() {
 
 required_env "VENDOR_BASE_URL"
 required_env "ISSUER_BASE_URL"
-required_env "CLIENT_PRIVATE_KEY_PEM"
+required_env "CLIENT_PRIVATE_KEY_PEMS"
 required_env "CLIENT_PAYMENT_COUNT"
 required_env "CLIENT_CHANNEL_AMOUNT"
 

--- a/src/nanomoni/api/vendor_api/app.py
+++ b/src/nanomoni/api/vendor_api/app.py
@@ -20,6 +20,7 @@ from prometheus_client import (
 )
 
 from ...application.vendor.dtos import VendorPublicKeyDTO
+from ...cpu_affinity import pin_to_own_core
 from ...envs.vendor_env import get_settings, register_vendor_with_issuer
 from ...infrastructure.scripts import VENDOR_SCRIPTS
 from .dependencies import get_key_value_store_dependency
@@ -40,6 +41,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    # Runs once per Uvicorn worker process, which is the only place a worker can
+    # claim a core for itself: the parent process forks before any of this.
+    if settings.pin_workers_to_cores:
+        pin_to_own_core(label="vendor worker")
+
     # Shared issuer HTTP session (reused across requests; closed on shutdown).
     app.state.issuer_session = aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=10.0)

--- a/src/nanomoni/client/common.py
+++ b/src/nanomoni/client/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Literal
+from urllib.parse import urlsplit, urlunsplit
 
 from nanomoni.application.issuer.dtos import (
     GetPaymentChannelRequestDTO,
@@ -28,6 +29,34 @@ _VALID_MODES = {
     "paytree_first_opt",
     "paytree_child_pair",
 }
+
+
+def vendor_url_for_worker(base_url: str, index: int, port_count: int) -> str:
+    """Return ``base_url`` with its port shifted to the worker serving ``index``.
+
+    The vendor runs one listening socket per worker on consecutive ports, so
+    choosing a port is choosing a worker. Spreading virtual clients round-robin
+    over ``port_count`` ports gives every worker the same number of clients,
+    which the shared accept queue of a single socket does not.
+
+    ``port_count`` of 1 (or a base URL with no explicit port) returns the URL
+    unchanged, so single-worker setups need no special casing.
+    """
+    if port_count <= 1:
+        return base_url
+
+    split = urlsplit(base_url)
+    if split.port is None or split.hostname is None:
+        return base_url
+
+    port = split.port + index % port_count
+    netloc = f"{split.hostname}:{port}"
+    if split.username:
+        credentials = split.username
+        if split.password:
+            credentials = f"{credentials}:{split.password}"
+        netloc = f"{credentials}@{netloc}"
+    return urlunsplit(split._replace(netloc=netloc))
 
 
 def validate_mode(mode: str) -> ClientMode:

--- a/src/nanomoni/client/common.py
+++ b/src/nanomoni/client/common.py
@@ -50,7 +50,10 @@ def vendor_url_for_worker(base_url: str, index: int, port_count: int) -> str:
         return base_url
 
     port = split.port + index % port_count
-    netloc = f"{split.hostname}:{port}"
+    host = split.hostname
+    if ":" in host:  # urlsplit strips IPv6 brackets; a netloc needs them back
+        host = f"[{host}]"
+    netloc = f"{host}:{port}"
     if split.username:
         credentials = split.username
         if split.password:

--- a/src/nanomoni/client_pay_chan.py
+++ b/src/nanomoni/client_pay_chan.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import AsyncExitStack
+from multiprocessing import get_context
 
 from nanomoni.application.issuer.dtos import (
     RegistrationRequestDTO,
@@ -11,10 +13,12 @@ from nanomoni.client import (
     payword,
     signature,
 )
+from nanomoni.cpu_affinity import pin_to_own_core
 from nanomoni.crypto.certificates import load_private_key_from_pem
+from nanomoni.crypto.key_utils import compute_public_key_der_b64_from_private_pem
 from nanomoni.crypto.paytree import Paytree
 from nanomoni.crypto.payword import Payword
-from nanomoni.envs.client_env import get_settings
+from nanomoni.envs.client_env import Settings, get_settings
 from nanomoni.infrastructure.http.http_client import HttpError
 from nanomoni.infrastructure.issuer.issuer_client import AsyncIssuerClient
 from nanomoni.infrastructure.vendor.vendor_client_async import VendorClientAsync
@@ -24,7 +28,227 @@ PAYWORD_NOT_INITIALIZED = "PayWord object should be initialized"
 PAYTREE_NOT_INITIALIZED = "PayTree object should be initialized"
 
 
-async def run_client_flow() -> None:
+async def _run_virtual_client(
+    issuer: AsyncIssuerClient,
+    vendor: VendorClientAsync,
+    vendor_public_key_der_b64: str,
+    settings: Settings,
+    client_mode: common.ClientMode,
+    client_private_key_pem: str,
+    payment_count: int,
+    channel_amount: int,
+    target_tps: float,
+) -> None:
+    """Drive one virtual client's full lifecycle: register, open a channel,
+    send its share of payments, settle, and verify its own balance.
+
+    Every piece of per-identity state (private key, payment count, channel
+    amount, target TPS) is an explicit argument so that N of these can run
+    concurrently via ``asyncio.gather`` in ``run_client_flow`` without sharing
+    identity/channel/counter state.
+    """
+    client_private_key = load_private_key_from_pem(client_private_key_pem)
+    client_public_key_der_b64 = compute_public_key_der_b64_from_private_pem(
+        client_private_key_pem
+    )
+
+    # Generate monotonic sequence:
+    # - signature mode: these are cumulative_owed_amount values
+    # - payword mode: these are k counters (cumulative_owed_amount = k * unit_value)
+    payments: list[int] = list(range(1, payment_count + 1))
+
+    # 3) Register client and capture starting balance (issuer returns existing balance).
+    initial = await issuer.register(
+        RegistrationRequestDTO(client_public_key_der_b64=client_public_key_der_b64)
+    )
+    initial_balance = initial.balance
+
+    # 4) Open channel (client-signed envelope)
+    # Initialize mode-specific commitments and compute final owed amount.
+    # Commitment construction is tens of thousands of synchronous hashes. Run it
+    # in a worker thread so the other virtual clients sharing this event loop
+    # keep servicing their sockets; a multi-second stall here lets the server
+    # close their idle keep-alive connections mid-flight.
+    final_cumulative_owed_amount: int
+    payword_obj: Payword | None = None
+    paytree_obj: Paytree | None = None
+
+    if client_mode == "payword":
+        (
+            payword_obj,
+            payword_root_b64,
+            payword_unit_value,
+            payword_max_k,
+        ) = await asyncio.to_thread(payword.init_commitment, settings, payment_count)
+        final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
+            client_mode, payments, payword_unit_value
+        )
+    elif client_mode in ("paytree", "paytree_first_opt"):
+        (
+            paytree_obj,
+            paytree_root_b64,
+            paytree_unit_value,
+            paytree_max_i,
+        ) = await asyncio.to_thread(paytree.init_commitment, settings, payment_count)
+        final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
+            client_mode, payments, paytree_unit_value
+        )
+    elif client_mode == "paytree_child_pair":
+        (
+            child_pair_tree,
+            paytree_root_b64,
+            paytree_unit_value,
+            paytree_max_i,
+        ) = await asyncio.to_thread(
+            paytree.init_commitment_child_pair, settings, payment_count
+        )
+        paytree_obj = child_pair_tree
+        # Child-pair payments are indexed by Eytzinger node k (1..max_k),
+        # not by leaf index; clip the requested payment count to max_k.
+        payments = list(range(1, min(payment_count, child_pair_tree.max_k) + 1))
+        final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
+            client_mode, payments, paytree_unit_value
+        )
+    else:
+        final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
+            client_mode, payments
+        )
+
+    # Sign and send open channel request
+    if client_mode == "payword":
+        open_dto = payword.build_open_channel_request(
+            client_private_key,
+            client_public_key_der_b64,
+            vendor_public_key_der_b64,
+            channel_amount,
+            payword_root_b64,
+            payword_unit_value,
+            payword_max_k,
+        )
+    elif client_mode in ("paytree", "paytree_first_opt", "paytree_child_pair"):
+        open_dto = paytree.build_open_channel_request(
+            client_private_key,
+            client_public_key_der_b64,
+            vendor_public_key_der_b64,
+            channel_amount,
+            paytree_root_b64,
+            paytree_unit_value,
+            paytree_max_i,
+        )
+    else:
+        open_dto = signature.build_open_channel_request(
+            client_private_key,
+            client_public_key_der_b64,
+            vendor_public_key_der_b64,
+            channel_amount,
+        )
+    channel_id = await common.open_channel_for_mode(issuer, client_mode, open_dto)
+
+    # Read balance after lock (issuer register is idempotent; using it as a "get balance").
+    after_open = await issuer.register(
+        RegistrationRequestDTO(client_public_key_der_b64=client_public_key_der_b64)
+    )
+    balance_after_open = after_open.balance
+
+    # 5) Payments
+    delay = 1.0 / target_tps if target_tps > 0 else 0.0
+
+    if client_mode == "signature":
+        # One ECDSA signature per payment, so this blocks for seconds at
+        # benchmark payment counts; keep it off the shared event loop.
+        payment_dtos = await asyncio.to_thread(
+            signature.prepare_payments,
+            channel_id,
+            client_public_key_der_b64,
+            vendor_public_key_der_b64,
+            client_private_key,
+            payments,
+        )
+        await signature.send_payments(
+            vendor, channel_id, payment_dtos, inter_payment_delay=delay
+        )
+    elif client_mode == "payword":
+        if payword_obj is None:
+            raise RuntimeError(PAYWORD_NOT_INITIALIZED)
+        # Type narrowing: mypy now knows payword_obj is not None after the check
+        payword_for_payments: Payword = payword_obj
+        await payword.send_payments(
+            vendor,
+            channel_id,
+            payword_for_payments,
+            payments,
+            inter_payment_delay=delay,
+        )
+    elif client_mode == "paytree":
+        if paytree_obj is None:
+            raise RuntimeError(PAYTREE_NOT_INITIALIZED)
+        paytree_for_payments = paytree_obj
+        await paytree.send_std_payments(
+            vendor,
+            channel_id,
+            paytree_for_payments,
+            payments,
+            inter_payment_delay=delay,
+        )
+    elif client_mode == "paytree_first_opt":
+        if paytree_obj is None:
+            raise RuntimeError(PAYTREE_NOT_INITIALIZED)
+        paytree_for_payments = paytree_obj
+        await paytree.send_first_opt_payments(
+            vendor,
+            channel_id,
+            paytree_for_payments,
+            payments,
+            inter_payment_delay=delay,
+        )
+    elif client_mode == "paytree_child_pair":
+        if paytree_obj is None:
+            raise RuntimeError(PAYTREE_NOT_INITIALIZED)
+        paytree_for_payments = paytree_obj
+        await paytree.send_child_pair_payments(
+            vendor,
+            channel_id,
+            paytree_for_payments,
+            payments,
+            inter_payment_delay=delay,
+        )
+    else:
+        raise RuntimeError(f"Unsupported client mode: {client_mode}")
+
+    # 6) Closure request (vendor will call issuer settlement)
+    await common.request_settle_for_mode(vendor, client_mode, channel_id)
+
+    # Wait until issuer marks the channel closed.
+    await common.wait_until_closed(issuer, client_mode, channel_id)
+
+    # 7) Assertion: client received remainder back on settlement.
+    # Expected:
+    # - After open: initial - channel_amount
+    # - After close: initial - final_cumulative_owed_amount
+    final = await issuer.register(
+        RegistrationRequestDTO(client_public_key_der_b64=client_public_key_der_b64)
+    )
+    final_balance = final.balance
+
+    expected_after_open = initial_balance - channel_amount
+    expected_final = initial_balance - final_cumulative_owed_amount
+    expected_remainder = channel_amount - final_cumulative_owed_amount
+
+    assert balance_after_open == expected_after_open, (
+        f"Unexpected balance after open. got={balance_after_open}, "
+        f"expected={expected_after_open}"
+    )
+    assert expected_remainder > 0, "Channel amount must exceed final owed amount"
+    assert final_balance == expected_final, (
+        f"Unexpected final client balance. got={final_balance}, expected={expected_final}"
+    )
+    assert final_balance - balance_after_open == expected_remainder, (
+        "Client did not receive remainder back as expected. "
+        f"got_delta={final_balance - balance_after_open}, expected_delta={expected_remainder}"
+    )
+
+
+async def run_client_flow(shard_index: int = 0, shard_count: int = 1) -> None:
     """
     Minimal client runner.
 
@@ -33,27 +257,44 @@ async def run_client_flow() -> None:
     - Open a payment channel to the vendor
     - Send a configurable sequence of off-chain payments to the vendor
     - Optionally request channel closure from the vendor
+
+    Fans out across one virtual client per entry in
+    ``settings.client_private_key_pems`` (own keypair + channel + payment loop
+    each), driven concurrently in-process via ``asyncio.gather``. With a
+    single key, this reproduces the single-identity behavior exactly.
+
+    ``shard_index``/``shard_count`` take only every Nth key, so several processes
+    can split the same key list (see ``main``). Per-key payment count and target
+    TPS stay derived from the *full* list, which keeps the totals a run delivers
+    identical no matter how many processes it is spread over.
     """
     settings = get_settings()
-    client_private_key = load_private_key_from_pem(settings.client_private_key_pem)
-
-    payment_count = settings.client_payment_count
-    # Default channel amount leaves a remainder so the client "receives funds back" on settlement.
-    channel_amount = settings.client_channel_amount
-
     client_mode = common.validate_mode(settings.client_payment_mode)
+    all_client_keys = settings.client_private_key_pems
+    n = len(all_client_keys)
+    # Position in the full key list, not in this shard: it decides which vendor
+    # worker the client talks to, and only a global index spreads clients evenly
+    # across workers when several processes each take a slice.
+    client_entries = list(enumerate(all_client_keys))[shard_index::shard_count]
+    if not client_entries:
+        return
 
-    # Generate monotonic sequence:
-    # - signature mode: these are cumulative_owed_amount values
-    # - payword mode: these are k counters (cumulative_owed_amount = k * unit_value)
-    payments: list[int] = list(range(1, payment_count + 1))
+    if settings.client_payment_count % n != 0:
+        raise RuntimeError(
+            "CLIENT_PAYMENT_COUNT must be evenly divisible by the number of "
+            "keys in CLIENT_PRIVATE_KEY_PEMS"
+        )
+    per_client_count = settings.client_payment_count // n
+    per_client_target_tps = (
+        settings.client_target_tps / n if settings.client_target_tps > 0 else 0.0
+    )
 
     async with (
         AsyncIssuerClient(settings.issuer_base_url) as issuer,
-        VendorClientAsync(settings.vendor_base_url) as vendor,
+        VendorClientAsync(settings.vendor_base_url) as bootstrap_vendor,
     ):
         # 1) Fetch vendor public key (required for opening channel + addressing payments)
-        vendor_pk = await vendor.get_vendor_public_key()
+        vendor_pk = await bootstrap_vendor.get_vendor_public_key()
 
         # 2) Ensure vendor is registered (idempotent in practice)
         try:
@@ -66,206 +307,76 @@ async def run_client_flow() -> None:
             # Vendor may already be registered; ignore 4xx/5xx here to keep runner minimal.
             pass
 
-        # 3) Register client and capture starting balance (issuer returns existing balance).
-        initial = await issuer.register(
-            RegistrationRequestDTO(
-                client_public_key_der_b64=settings.client_public_key_der_b64
-            )
-        )
-        initial_balance = initial.balance
-
-        # 4) Open channel (client-signed envelope)
-        # Initialize mode-specific commitments and compute final owed amount
-        final_cumulative_owed_amount: int
-        payword_obj: Payword | None = None
-        paytree_obj: Paytree | None = None
-
-        if client_mode == "payword":
-            payword_obj, payword_root_b64, payword_unit_value, payword_max_k = (
-                payword.init_commitment(settings, payment_count)
-            )
-            final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
-                client_mode, payments, payword_unit_value
-            )
-        elif client_mode in ("paytree", "paytree_first_opt"):
-            paytree_obj, paytree_root_b64, paytree_unit_value, paytree_max_i = (
-                paytree.init_commitment(settings, payment_count)
-            )
-            final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
-                client_mode, payments, paytree_unit_value
-            )
-        elif client_mode == "paytree_child_pair":
-            paytree_obj, paytree_root_b64, paytree_unit_value, paytree_max_i = (
-                paytree.init_commitment_child_pair(settings, payment_count)
-            )
-            # Child-pair payments are indexed by Eytzinger node k (1..max_k),
-            # not by leaf index; clip the requested payment count to max_k.
-            payments = list(range(1, min(payment_count, paytree_obj.max_k) + 1))
-            final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
-                client_mode, payments, paytree_unit_value
-            )
-        else:
-            final_cumulative_owed_amount = common.compute_final_cumulative_owed_amount(
-                client_mode, payments
+        # One dedicated vendor connection per virtual client, aimed at the port of
+        # the worker this client belongs to. A keep-alive connection is served end
+        # to end by the worker that accepted it, so a pool capped at one
+        # connection keeps every payment of a channel on that worker; sharing one
+        # pool would instead hand consecutive payments to whichever connection
+        # happened to be free.
+        async with AsyncExitStack() as stack:
+            vendors = [
+                await stack.enter_async_context(
+                    VendorClientAsync(
+                        common.vendor_url_for_worker(
+                            settings.vendor_base_url,
+                            index,
+                            settings.client_vendor_port_count,
+                        ),
+                        connection_limit=1,
+                    )
+                )
+                for index, _ in client_entries
+            ]
+            await asyncio.gather(
+                *(
+                    _run_virtual_client(
+                        issuer,
+                        own_vendor,
+                        vendor_pk.public_key_der_b64,
+                        settings,
+                        client_mode,
+                        key_pem,
+                        per_client_count,
+                        settings.client_channel_amount,
+                        per_client_target_tps,
+                    )
+                    for own_vendor, (_, key_pem) in zip(vendors, client_entries)
+                )
             )
 
-        # Sign and send open channel request
-        if client_mode == "payword":
-            open_dto = payword.build_open_channel_request(
-                client_private_key,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                channel_amount,
-                payword_root_b64,
-                payword_unit_value,
-                payword_max_k,
-            )
-        elif client_mode == "paytree":
-            open_dto = paytree.build_open_channel_request(
-                client_private_key,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                channel_amount,
-                paytree_root_b64,
-                paytree_unit_value,
-                paytree_max_i,
-            )
-        elif client_mode == "paytree_first_opt":
-            open_dto = paytree.build_open_channel_request(
-                client_private_key,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                channel_amount,
-                paytree_root_b64,
-                paytree_unit_value,
-                paytree_max_i,
-            )
-        elif client_mode == "paytree_child_pair":
-            open_dto = paytree.build_open_channel_request(
-                client_private_key,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                channel_amount,
-                paytree_root_b64,
-                paytree_unit_value,
-                paytree_max_i,
-            )
-        else:
-            open_dto = signature.build_open_channel_request(
-                client_private_key,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                channel_amount,
-            )
-        channel_id = await common.open_channel_for_mode(issuer, client_mode, open_dto)
 
-        # Read balance after lock (issuer register is idempotent; using it as a "get balance").
-        after_open = await issuer.register(
-            RegistrationRequestDTO(
-                client_public_key_der_b64=settings.client_public_key_der_b64
-            )
-        )
-        balance_after_open = after_open.balance
-
-        # 5) Payments
-        delay = settings.inter_payment_delay_s
-
-        if client_mode == "signature":
-            payment_dtos = signature.prepare_payments(
-                channel_id,
-                settings.client_public_key_der_b64,
-                vendor_pk.public_key_der_b64,
-                client_private_key,
-                payments,
-            )
-            await signature.send_payments(
-                vendor, channel_id, payment_dtos, inter_payment_delay=delay
-            )
-        elif client_mode == "payword":
-            if payword_obj is None:
-                raise RuntimeError(PAYWORD_NOT_INITIALIZED)
-            # Type narrowing: mypy now knows payword_obj is not None after the check
-            payword_for_payments: Payword = payword_obj
-            await payword.send_payments(
-                vendor,
-                channel_id,
-                payword_for_payments,
-                payments,
-                inter_payment_delay=delay,
-            )
-        elif client_mode == "paytree":
-            if paytree_obj is None:
-                raise RuntimeError(PAYTREE_NOT_INITIALIZED)
-            paytree_for_payments = paytree_obj
-            await paytree.send_std_payments(
-                vendor,
-                channel_id,
-                paytree_for_payments,
-                payments,
-                inter_payment_delay=delay,
-            )
-        elif client_mode == "paytree_first_opt":
-            if paytree_obj is None:
-                raise RuntimeError(PAYTREE_NOT_INITIALIZED)
-            paytree_for_payments = paytree_obj
-            await paytree.send_first_opt_payments(
-                vendor,
-                channel_id,
-                paytree_for_payments,
-                payments,
-                inter_payment_delay=delay,
-            )
-        elif client_mode == "paytree_child_pair":
-            if paytree_obj is None:
-                raise RuntimeError(PAYTREE_NOT_INITIALIZED)
-            paytree_for_payments = paytree_obj
-            await paytree.send_child_pair_payments(
-                vendor,
-                channel_id,
-                paytree_for_payments,
-                payments,
-                inter_payment_delay=delay,
-            )
-        else:
-            raise RuntimeError(f"Unsupported client mode: {client_mode}")
-
-        # 6) Closure request (vendor will call issuer settlement)
-        await common.request_settle_for_mode(vendor, client_mode, channel_id)
-
-        # Wait until issuer marks the channel closed.
-        await common.wait_until_closed(issuer, client_mode, channel_id)
-
-        # 7) Assertion: client received remainder back on settlement.
-        # Expected:
-        # - After open: initial - channel_amount
-        # - After close: initial - final_cumulative_owed_amount
-        final = await issuer.register(
-            RegistrationRequestDTO(
-                client_public_key_der_b64=settings.client_public_key_der_b64
-            )
-        )
-        final_balance = final.balance
-
-        expected_after_open = initial_balance - channel_amount
-        expected_final = initial_balance - final_cumulative_owed_amount
-        expected_remainder = channel_amount - final_cumulative_owed_amount
-
-        assert balance_after_open == expected_after_open, (
-            f"Unexpected balance after open. got={balance_after_open}, "
-            f"expected={expected_after_open}"
-        )
-        assert expected_remainder > 0, "Channel amount must exceed final owed amount"
-        assert final_balance == expected_final, (
-            f"Unexpected final client balance. got={final_balance}, expected={expected_final}"
-        )
-        assert final_balance - balance_after_open == expected_remainder, (
-            "Client did not receive remainder back as expected. "
-            f"got_delta={final_balance - balance_after_open}, expected_delta={expected_remainder}"
-        )
+def _run_shard(shard_index: int, shard_count: int) -> None:
+    settings = get_settings()
+    if settings.client_pin_processes_to_cores:
+        pin_to_own_core(label=f"client shard {shard_index}")
+    asyncio.run(run_client_flow(shard_index, shard_count))
 
 
 def main() -> None:
-    asyncio.run(run_client_flow())
+    shard_count = get_settings().client_processes
+    if shard_count == 1:
+        _run_shard(0, 1)
+        return
+
+    # Virtual clients share one event loop and one GIL, so a client asked to
+    # drive more TPS than a single core can produce needs more processes, not
+    # more virtual clients. Keys are dealt round-robin, so shards differ by at
+    # most one client when the count does not divide evenly.
+    ctx = get_context("fork")
+    procs = [
+        ctx.Process(target=_run_shard, args=(i, shard_count), name=f"client-shard-{i}")
+        for i in range(shard_count)
+    ]
+    for proc in procs:
+        proc.start()
+
+    failures = []
+    for proc in procs:
+        proc.join()
+        if proc.exitcode != 0:
+            failures.append(f"{proc.name} exited with {proc.exitcode}")
+    if failures:
+        raise SystemExit("; ".join(failures))
 
 
 if __name__ == "__main__":

--- a/src/nanomoni/cpu_affinity.py
+++ b/src/nanomoni/cpu_affinity.py
@@ -1,0 +1,61 @@
+"""Pin one process to one core.
+
+Docker's ``cpuset`` constrains a container to a set of cores but leaves the
+kernel free to migrate its processes among them, so a vendor worker can move
+between cores mid-run and pay an L3 miss on arrival. Owning a core for the
+process's whole life removes that variance, and it can only be expressed from
+inside the container, per process.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+from typing import IO
+
+LOCK_DIR = "/tmp/nanomoni-cpu-pins"
+
+# The kernel releases an flock when the holder exits, which is exactly the
+# lifetime we want -- but only for as long as the fd stays open, so the handles
+# are parked here instead of being closed when pin_to_own_core returns.
+_held_locks: list[IO[bytes]] = []
+
+
+def pin_to_own_core(*, label: str, lock_dir: str = LOCK_DIR) -> int | None:
+    """Claim one core out of this process's allowed set and pin the process to it.
+
+    Each core is claimed through an exclusive lock file, so sibling processes of
+    the same container never pick the same core and a restarted process reclaims
+    whichever core its predecessor released. Returns the claimed core, or
+    ``None`` when there are more processes than allowed cores (or the platform
+    has no affinity calls), leaving the inherited affinity untouched.
+
+    Reports through ``print`` rather than ``logging`` because both callers are
+    process bootstrap paths where the root logger has no handler yet: Uvicorn
+    configures only its own loggers, and the client configures none.
+    """
+    if not hasattr(os, "sched_setaffinity"):
+        print(f"{label}: not pinned, platform has no CPU affinity support", flush=True)
+        return None
+
+    allowed = sorted(os.sched_getaffinity(0))
+    os.makedirs(lock_dir, exist_ok=True)
+
+    for core in allowed:
+        handle = open(os.path.join(lock_dir, f"core-{core}.lock"), "wb")
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            handle.close()
+            continue
+        _held_locks.append(handle)
+        os.sched_setaffinity(0, {core})
+        print(f"{label} (pid {os.getpid()}): pinned to core {core}", flush=True)
+        return core
+
+    print(
+        f"{label} (pid {os.getpid()}): not pinned, all {len(allowed)} allowed "
+        "core(s) are already claimed",
+        flush=True,
+    )
+    return None

--- a/src/nanomoni/cpu_affinity.py
+++ b/src/nanomoni/cpu_affinity.py
@@ -13,7 +13,7 @@ import fcntl
 import os
 from typing import IO
 
-LOCK_DIR = "/tmp/nanomoni-cpu-pins"
+LOCK_DIR = "/tmp/nanomoni-cpu-pins"  # noqa: S108 -- container-local by design, see module docstring
 
 # The kernel releases an flock when the holder exits, which is exactly the
 # lifetime we want -- but only for as long as the fd stays open, so the handles

--- a/src/nanomoni/envs/client_env.py
+++ b/src/nanomoni/envs/client_env.py
@@ -1,23 +1,33 @@
 from __future__ import annotations
 
+import json
 import math
 import os
 from functools import lru_cache
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, field_validator
 from cryptography.hazmat.primitives import serialization
 from urllib.parse import urlparse
 
-from nanomoni.crypto.key_utils import compute_public_key_der_b64_from_private_pem
-
 
 class Settings(BaseModel):
-    client_private_key_pem: str
-    # Precomputed at settings load time to avoid re-parsing the private key on every access.
-    client_public_key_der_b64: str
+    # One PEM-encoded private key per virtual client (own keypair + channel +
+    # payment loop, driven concurrently in-process). The client count is
+    # simply len(client_private_key_pems) -- there is no separate count field.
+    client_private_key_pems: List[str]
     vendor_base_url: str
     issuer_base_url: str
+    # OS processes the virtual clients are spread across. One asyncio loop
+    # saturates a single core -- the payment loop and its crypto both hold the
+    # GIL -- so this is what turns extra client cores into extra throughput.
+    client_processes: int = 1
+    # Pin each of those processes to a single core of the container's cpuset.
+    client_pin_processes_to_cores: bool = False
+    # Consecutive vendor ports to spread virtual clients over, one per vendor
+    # worker (keep equal to VENDOR_API_WORKERS). 1 sends everything to the port
+    # in vendor_base_url.
+    client_vendor_port_count: int = 1
     client_payment_count: int = 1
     client_channel_amount: int = 1
     # signature | payword | paytree | paytree_first_opt (paytree with pruned proofs, opt type 1)
@@ -40,19 +50,22 @@ class Settings(BaseModel):
         """
         return 1.0 / self.client_target_tps if self.client_target_tps > 0 else 0.0
 
-    @field_validator("client_private_key_pem")
+    @field_validator("client_private_key_pems")
     @classmethod
-    def validate_client_private_key_pem(cls, v: str) -> str:
-        """Validate that the client private key is a valid PEM-encoded private key."""
+    def validate_client_private_key_pems(cls, v: List[str]) -> List[str]:
+        """Validate that every entry is a non-empty, PEM-encoded private key."""
         if not v:
-            raise ValueError("Client private key cannot be empty")
-        try:
-            serialization.load_pem_private_key(
-                v.encode(),
-                password=None,
-            )
-        except Exception as e:
-            raise ValueError(f"Invalid client private key PEM: {e}") from e
+            raise ValueError("client_private_key_pems cannot be empty")
+        for pem in v:
+            if not pem:
+                raise ValueError("Client private key cannot be empty")
+            try:
+                serialization.load_pem_private_key(
+                    pem.encode(),
+                    password=None,
+                )
+            except Exception as e:
+                raise ValueError(f"Invalid client private key PEM: {e}") from e
         return v
 
     @field_validator("vendor_base_url")
@@ -79,6 +92,20 @@ class Settings(BaseModel):
             raise ValueError("Issuer base URL must include a host")
         return v
 
+    @field_validator("client_processes")
+    @classmethod
+    def validate_client_processes(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("client_processes must be at least 1")
+        return v
+
+    @field_validator("client_vendor_port_count")
+    @classmethod
+    def validate_client_vendor_port_count(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("client_vendor_port_count must be at least 1")
+        return v
+
     @field_validator("client_target_tps")
     @classmethod
     def validate_target_tps(cls, v: float) -> float:
@@ -91,7 +118,7 @@ class Settings(BaseModel):
 
 @lru_cache
 def get_settings() -> Settings:
-    client_private_key_pem = os.environ.get("CLIENT_PRIVATE_KEY_PEM")
+    client_private_key_pems_str = os.environ.get("CLIENT_PRIVATE_KEY_PEMS")
     vendor_base_url = os.environ.get("VENDOR_BASE_URL")
     issuer_base_url = os.environ.get("ISSUER_BASE_URL")
     client_payment_count_str = os.environ.get("CLIENT_PAYMENT_COUNT")
@@ -101,12 +128,26 @@ def get_settings() -> Settings:
     client_payword_max_k_str = os.environ.get("CLIENT_PAYWORD_MAX_K")
     client_paytree_unit_value_str = os.environ.get("CLIENT_PAYTREE_UNIT_VALUE")
     client_paytree_max_i_str = os.environ.get("CLIENT_PAYTREE_MAX_I")
-    if not (client_private_key_pem and vendor_base_url and issuer_base_url):
+    client_processes_str = os.environ.get("CLIENT_PROCESSES")
+    client_pin_processes_str = os.environ.get("CLIENT_PIN_PROCESSES_TO_CORES")
+    client_vendor_port_count_str = os.environ.get("CLIENT_VENDOR_PORT_COUNT")
+    if not (client_private_key_pems_str and vendor_base_url and issuer_base_url):
         raise ValueError(
-            "CLIENT_PRIVATE_KEY_PEM, VENDOR_BASE_URL, and ISSUER_BASE_URL are required"
+            "CLIENT_PRIVATE_KEY_PEMS, VENDOR_BASE_URL, and ISSUER_BASE_URL are required"
         )
     if client_payment_count_str is None or client_channel_amount_str is None:
         raise ValueError("CLIENT_PAYMENT_COUNT and CLIENT_CHANNEL_AMOUNT are required")
+
+    try:
+        client_private_key_pems = json.loads(client_private_key_pems_str)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"Invalid JSON array for CLIENT_PRIVATE_KEY_PEMS: {client_private_key_pems_str!r}"
+        ) from e
+    if not isinstance(client_private_key_pems, list) or not all(
+        isinstance(pem, str) for pem in client_private_key_pems
+    ):
+        raise ValueError("CLIENT_PRIVATE_KEY_PEMS must be a JSON array of PEM strings")
 
     try:
         client_payment_count = int(client_payment_count_str)
@@ -158,6 +199,26 @@ def get_settings() -> Settings:
     else:
         client_paytree_max_i = None
 
+    try:
+        client_processes = int(client_processes_str) if client_processes_str else 1
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid integer for CLIENT_PROCESSES: {client_processes_str!r}"
+        ) from e
+
+    client_pin_processes_to_cores = (
+        client_pin_processes_str or "false"
+    ).lower() == "true"
+
+    try:
+        client_vendor_port_count = (
+            int(client_vendor_port_count_str) if client_vendor_port_count_str else 1
+        )
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid integer for CLIENT_VENDOR_PORT_COUNT: {client_vendor_port_count_str!r}"
+        ) from e
+
     client_target_tps_str = os.environ.get("CLIENT_TARGET_TPS")
     if client_target_tps_str:
         try:
@@ -170,12 +231,12 @@ def get_settings() -> Settings:
         client_target_tps = 0.0
 
     return Settings(
-        client_private_key_pem=client_private_key_pem,
-        client_public_key_der_b64=compute_public_key_der_b64_from_private_pem(
-            client_private_key_pem
-        ),
+        client_private_key_pems=client_private_key_pems,
         vendor_base_url=vendor_base_url,
         issuer_base_url=issuer_base_url,
+        client_processes=client_processes,
+        client_pin_processes_to_cores=client_pin_processes_to_cores,
+        client_vendor_port_count=client_vendor_port_count,
         client_payment_count=client_payment_count,
         client_channel_amount=client_channel_amount,
         client_payment_mode=client_payment_mode,

--- a/src/nanomoni/envs/vendor_env.py
+++ b/src/nanomoni/envs/vendor_env.py
@@ -22,6 +22,10 @@ class Settings(BaseModel):
     api_debug: bool
     api_workers: int
     api_cors_origins: list[str]
+    # Pin each Uvicorn worker to a single core of the container's cpuset, so the
+    # kernel cannot migrate it mid-run. Only meaningful when the cpuset has at
+    # least as many cores as there are workers.
+    pin_workers_to_cores: bool = False
 
     app_name: str
     app_version: str
@@ -100,6 +104,7 @@ def get_settings() -> Settings:
     api_cors_origins_str = os.environ.get("VENDOR_API_CORS_ORIGINS")
     api_port_str = os.environ.get("VENDOR_API_PORT")
     api_workers_str = os.environ.get("VENDOR_API_WORKERS")
+    pin_workers_str = os.environ.get("VENDOR_PIN_WORKERS_TO_CORES")
 
     vendor_private_key_pem = os.environ.get("VENDOR_PRIVATE_KEY_PEM")
     issuer_base_url = os.environ.get("ISSUER_BASE_URL")
@@ -114,6 +119,7 @@ def get_settings() -> Settings:
     api_debug = (api_debug_str or "false").lower() == "true"
     api_workers = int(api_workers_str) if api_workers_str is not None else 1
     api_cors_origins = api_cors_origins_str.split(",") if api_cors_origins_str else []
+    pin_workers_to_cores = (pin_workers_str or "false").lower() == "true"
 
     app_name = os.environ.get("VENDOR_APP_NAME") or "NanoMoni"
     app_version = os.environ.get("VENDOR_APP_VERSION") or "0.1.0"
@@ -145,6 +151,7 @@ def get_settings() -> Settings:
         api_debug=api_debug,
         api_workers=api_workers,
         api_cors_origins=api_cors_origins,
+        pin_workers_to_cores=pin_workers_to_cores,
         app_name=app_name,
         app_version=app_version,
         issuer_base_url=issuer_base_url,

--- a/src/nanomoni/infrastructure/http/http_client.py
+++ b/src/nanomoni/infrastructure/http/http_client.py
@@ -13,6 +13,14 @@ from urllib.request import Request, urlopen
 import aiohttp
 
 
+# Mirrors the vendor's timeout_keep_alive (see nanomoni.main). aiohttp drops a
+# pooled connection after 15s idle by default, and a reconnect is accepted by
+# whichever worker wins the race -- so a dedicated connection needs to survive
+# idle gaps for as long as the server is willing to hold it, or the affinity it
+# exists to provide quietly disappears.
+DEDICATED_CONNECTION_KEEPALIVE_S = 120.0
+
+
 class HttpError(Exception):
     """Base error for HTTP client operations."""
 
@@ -272,6 +280,10 @@ class AsyncHttpClient:
 
     If ``session`` is provided, this client borrows it and will not close it in
     ``aclose`` / ``__aexit__`` (caller owns the connection pool / keep-alive).
+
+    ``connection_limit`` caps the size of the pool this client owns; it is
+    ignored when a session is borrowed. Set it to 1 to make every request travel
+    over the same connection.
     """
 
     def __init__(
@@ -280,6 +292,7 @@ class AsyncHttpClient:
         timeout: float = 10.0,
         *,
         session: aiohttp.ClientSession | None = None,
+        connection_limit: int | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._timeout = aiohttp.ClientTimeout(total=timeout)
@@ -287,7 +300,17 @@ class AsyncHttpClient:
             self._client = session
             self._owns_session = False
         else:
-            self._client = aiohttp.ClientSession(timeout=self._timeout)
+            connector = (
+                None
+                if connection_limit is None
+                else aiohttp.TCPConnector(
+                    limit=connection_limit,
+                    keepalive_timeout=DEDICATED_CONNECTION_KEEPALIVE_S,
+                )
+            )
+            self._client = aiohttp.ClientSession(
+                timeout=self._timeout, connector=connector
+            )
             self._owns_session = True
 
     def _url(self, path: str) -> str:
@@ -383,23 +406,41 @@ class AsyncHttpClient:
         else:
             auth_obj = auth
         url = self._url(path)
-        try:
-            async with self._client.request(
-                method,
-                url,
-                json=json,
-                headers=headers,
-                params=params,
-                timeout=timeout,
-                auth=auth_obj,
-                cookies=cookies,
-            ) as resp:
-                content = await resp.read()
-                response = HttpResponse(status_code=resp.status, content=content)
-        except asyncio.TimeoutError as e:
-            raise HttpRequestError(f"Request failed: {method} {url}", cause=e) from e
-        except aiohttp.ClientError as e:
-            raise HttpRequestError(f"Request failed: {method} {url}", cause=e) from e
+        # A connection idle in the pool can be closed by the server's keep-alive
+        # timeout right as we try to reuse it (e.g. after a long client-side
+        # computation between requests, such as building a large PayTree).
+        # aiohttp surfaces that as ServerDisconnectedError before any bytes are
+        # written, so the request never reached the server; retry once, which
+        # forces a fresh connection since the stale one is evicted on failure.
+        attempts = 2
+        for attempt in range(attempts):
+            try:
+                async with self._client.request(
+                    method,
+                    url,
+                    json=json,
+                    headers=headers,
+                    params=params,
+                    timeout=timeout,
+                    auth=auth_obj,
+                    cookies=cookies,
+                ) as resp:
+                    content = await resp.read()
+                    response = HttpResponse(status_code=resp.status, content=content)
+                break
+            except aiohttp.ServerDisconnectedError as e:
+                if attempt == attempts - 1:
+                    raise HttpRequestError(
+                        f"Request failed: {method} {url}", cause=e
+                    ) from e
+            except asyncio.TimeoutError as e:
+                raise HttpRequestError(
+                    f"Request failed: {method} {url}", cause=e
+                ) from e
+            except aiohttp.ClientError as e:
+                raise HttpRequestError(
+                    f"Request failed: {method} {url}", cause=e
+                ) from e
 
         if response.status_code >= 400:
             raise HttpResponseError(response)

--- a/src/nanomoni/infrastructure/vendor/vendor_client_async.py
+++ b/src/nanomoni/infrastructure/vendor/vendor_client_async.py
@@ -39,8 +39,11 @@ class VendorClientAsync:
         *,
         payment_retries: int = 2,
         payment_retry_backoff_s: float = 0.15,
+        connection_limit: int | None = None,
     ) -> None:
-        self._http = AsyncHttpClient(base_url, timeout=timeout)
+        self._http = AsyncHttpClient(
+            base_url, timeout=timeout, connection_limit=connection_limit
+        )
         self._payment_retries = payment_retries
         self._payment_retry_backoff_s = payment_retry_backoff_s
 

--- a/src/nanomoni/issuer_main.py
+++ b/src/nanomoni/issuer_main.py
@@ -16,6 +16,10 @@ if sys.platform != "win32":
 
 from .envs.issuer_env import get_settings
 
+# See the equivalent constant in nanomoni.main: uvicorn's 5s default drops idle
+# connections while a benchmark client's event loop is stalled on crypto.
+KEEP_ALIVE_TIMEOUT_SEC = 120
+
 
 def _setup_prometheus_multiproc_dir() -> None:
     """Prepare the Prometheus multiprocess directory before Uvicorn forks workers."""
@@ -50,6 +54,7 @@ def main() -> None:
         port=settings.api_port,
         reload=settings.api_debug,
         log_level="info",
+        timeout_keep_alive=KEEP_ALIVE_TIMEOUT_SEC,
     )
 
 

--- a/src/nanomoni/main.py
+++ b/src/nanomoni/main.py
@@ -84,7 +84,11 @@ def _serve_one_worker_per_port(host: str, base_port: int, count: int) -> int:
     for proc in procs:
         proc.start()
 
+    shutdown_requested = False
+
     def shutdown(signum: int, frame: FrameType | None) -> None:
+        nonlocal shutdown_requested
+        shutdown_requested = True
         for proc in procs:
             if proc.is_alive():
                 proc.terminate()
@@ -93,11 +97,15 @@ def _serve_one_worker_per_port(host: str, base_port: int, count: int) -> int:
     signal.signal(signal.SIGINT, shutdown)
 
     wait([proc.sentinel for proc in procs])
+    # A worker exiting without shutdown() having been asked for is a dropped
+    # port, even if that worker's own exit code was 0 -- the whole set must
+    # still report failure so a container orchestrator doesn't read this as a
+    # clean stop.
+    status = 0 if shutdown_requested else 1
     for proc in procs:
         if proc.is_alive():
             proc.terminate()
 
-    status = 0
     for proc in procs:
         proc.join()
         # terminate() shows up as -SIGTERM; that is this function doing its job.

--- a/src/nanomoni/main.py
+++ b/src/nanomoni/main.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import os
+import signal
 import sys
+from multiprocessing import get_context
+from multiprocessing.connection import wait
+from types import FrameType
+
 import uvicorn
 
 # Install uvloop for better async performance (Linux/macOS only)
@@ -15,6 +20,12 @@ if sys.platform != "win32":
         pass  # uvloop not available, continue with default event loop
 
 from .envs.vendor_env import get_settings
+
+# Uvicorn defaults this to 5s. Benchmark clients drive many virtual clients from
+# a single event loop and stall it for seconds while precomputing crypto; idle
+# pooled connections closed during such a stall make the client's next request
+# fail while writing its body. Hold idle connections past any plausible stall.
+KEEP_ALIVE_TIMEOUT_SEC = 120
 
 
 def _setup_prometheus_multiproc_dir() -> None:
@@ -34,6 +45,68 @@ def _setup_prometheus_multiproc_dir() -> None:
             os.remove(file_path)
 
 
+def _serve(host: str, port: int, *, reload: bool) -> None:
+    uvicorn.run(
+        "nanomoni.api.vendor_api.app:app",
+        host=host,
+        port=port,
+        reload=reload,
+        workers=1,
+        log_level="info",
+        timeout_keep_alive=KEEP_ALIVE_TIMEOUT_SEC,
+    )
+
+
+def _serve_one_worker_per_port(host: str, base_port: int, count: int) -> int:
+    """Run ``count`` single-worker servers on consecutive ports.
+
+    Uvicorn's own multi-worker mode has every worker accept from one shared
+    listening socket, and the kernel wakes whichever worker is quickest -- which
+    measurably piles connections onto a few workers and leaves others idle, so
+    the busy ones saturate their single core while the machine looks half used.
+    Giving each worker its own listening socket makes the port a client dials the
+    worker it reaches, which is what lets the load be spread deliberately.
+
+    Returns the exit status: a worker dying takes the whole set down, because a
+    surviving container missing one port would silently drop the traffic aimed
+    at it.
+    """
+    ctx = get_context("fork")
+    procs = [
+        ctx.Process(
+            target=_serve,
+            args=(host, base_port + index),
+            kwargs={"reload": False},
+            name=f"vendor-worker-{index}",
+        )
+        for index in range(count)
+    ]
+    for proc in procs:
+        proc.start()
+
+    def shutdown(signum: int, frame: FrameType | None) -> None:
+        for proc in procs:
+            if proc.is_alive():
+                proc.terminate()
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    wait([proc.sentinel for proc in procs])
+    for proc in procs:
+        if proc.is_alive():
+            proc.terminate()
+
+    status = 0
+    for proc in procs:
+        proc.join()
+        # terminate() shows up as -SIGTERM; that is this function doing its job.
+        if proc.exitcode not in (0, -signal.SIGTERM):
+            print(f"{proc.name} exited with {proc.exitcode}", flush=True)
+            status = 1
+    return status
+
+
 def main() -> None:
     """Main entry point for the vendor application."""
 
@@ -44,7 +117,6 @@ def main() -> None:
     print(f"API will be available at: http://{settings.api_host}:{settings.api_port}")
     print(f"API Documentation: http://{settings.api_host}:{settings.api_port}/docs")
 
-    # Run the FastAPI application.
     # If debug/reload is enabled, force a single worker (Uvicorn doesn't support
     # multi-worker with reload). Otherwise, use the configured number of workers
     # so the app can utilize multiple CPU cores.
@@ -53,14 +125,13 @@ def main() -> None:
 
     _setup_prometheus_multiproc_dir()
 
-    uvicorn.run(
-        "nanomoni.api.vendor_api.app:app",
-        host=settings.api_host,
-        port=settings.api_port,
-        reload=reload,
-        workers=workers,
-        log_level="info",
-    )
+    if workers == 1:
+        _serve(settings.api_host, settings.api_port, reload=reload)
+        return
+
+    ports = f"{settings.api_port}-{settings.api_port + workers - 1}"
+    print(f"Serving {workers} workers on ports {ports} (one listening socket each)")
+    sys.exit(_serve_one_worker_per_port(settings.api_host, settings.api_port, workers))
 
 
 if __name__ == "__main__":

--- a/tests/unit/client/test_vendor_url_for_worker.py
+++ b/tests/unit/client/test_vendor_url_for_worker.py
@@ -1,0 +1,43 @@
+"""Tests for spreading virtual clients across the vendor's per-worker ports."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from nanomoni.client.common import vendor_url_for_worker
+
+
+BASE = "http://vendor:8000/api/v1"
+
+
+def test_index_selects_a_consecutive_port() -> None:
+    assert vendor_url_for_worker(BASE, 0, 10) == "http://vendor:8000/api/v1"
+    assert vendor_url_for_worker(BASE, 3, 10) == "http://vendor:8003/api/v1"
+    assert vendor_url_for_worker(BASE, 9, 10) == "http://vendor:8009/api/v1"
+
+
+def test_indexes_wrap_around_the_worker_count() -> None:
+    assert vendor_url_for_worker(BASE, 10, 10) == vendor_url_for_worker(BASE, 0, 10)
+    assert vendor_url_for_worker(BASE, 23, 10) == "http://vendor:8003/api/v1"
+
+
+def test_a_multiple_of_the_worker_count_spreads_evenly() -> None:
+    """The whole point: every worker ends up with the same number of clients."""
+    counts = Counter(vendor_url_for_worker(BASE, i, 10) for i in range(40))
+    assert len(counts) == 10
+    assert set(counts.values()) == {4}
+
+
+def test_single_port_leaves_the_url_untouched() -> None:
+    assert vendor_url_for_worker(BASE, 7, 1) == BASE
+
+
+def test_url_without_an_explicit_port_is_left_untouched() -> None:
+    assert (
+        vendor_url_for_worker("http://vendor/api/v1", 7, 10) == "http://vendor/api/v1"
+    )
+
+
+def test_credentials_survive_the_port_change() -> None:
+    url = vendor_url_for_worker("http://user:pw@vendor:8000/api/v1", 2, 10)
+    assert url == "http://user:pw@vendor:8002/api/v1"

--- a/tests/unit/client/test_vendor_url_for_worker.py
+++ b/tests/unit/client/test_vendor_url_for_worker.py
@@ -41,3 +41,9 @@ def test_url_without_an_explicit_port_is_left_untouched() -> None:
 def test_credentials_survive_the_port_change() -> None:
     url = vendor_url_for_worker("http://user:pw@vendor:8000/api/v1", 2, 10)
     assert url == "http://user:pw@vendor:8002/api/v1"
+
+
+def test_ipv6_host_keeps_its_brackets() -> None:
+    """urlsplit strips IPv6 brackets from .hostname; the netloc needs them back."""
+    url = vendor_url_for_worker("http://[::1]:8000/api/v1", 3, 10)
+    assert url == "http://[::1]:8003/api/v1"

--- a/tests/unit/infrastructure/test_async_http_client_session.py
+++ b/tests/unit/infrastructure/test_async_http_client_session.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import aiohttp
 import pytest
 
-from nanomoni.infrastructure.http.http_client import AsyncHttpClient
+from nanomoni.infrastructure.http.http_client import (
+    AsyncHttpClient,
+    DEDICATED_CONNECTION_KEEPALIVE_S,
+)
 
 
 @pytest.mark.asyncio
@@ -27,6 +30,44 @@ async def test_owned_session_is_closed_on_aclose() -> None:
     owned = client._client
     await client.aclose()
     assert owned.closed
+
+
+@pytest.mark.asyncio
+async def test_connection_limit_caps_the_owned_pool() -> None:
+    """A limit of 1 is what keeps a virtual client on a single Uvicorn worker."""
+    client = AsyncHttpClient("http://example.test", connection_limit=1)
+    try:
+        connector = client._client.connector
+        assert connector is not None
+        assert connector.limit == 1
+        # Shorter than the vendor's keep-alive would silently drop the connection
+        # during an idle gap and let another worker accept the replacement.
+        assert connector._keepalive_timeout == DEDICATED_CONNECTION_KEEPALIVE_S
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pool_is_unbounded_without_a_connection_limit() -> None:
+    client = AsyncHttpClient("http://example.test")
+    try:
+        connector = client._client.connector
+        assert connector is not None
+        assert connector.limit != 1
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_borrowed_session_ignores_connection_limit() -> None:
+    shared = aiohttp.ClientSession()
+    try:
+        client = AsyncHttpClient(
+            "http://example.test", session=shared, connection_limit=1
+        )
+        assert client._client is shared
+    finally:
+        await shared.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/infrastructure/test_async_http_client_session.py
+++ b/tests/unit/infrastructure/test_async_http_client_session.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 import aiohttp
 import pytest
 
-from nanomoni.infrastructure.http.http_client import (
-    AsyncHttpClient,
-    DEDICATED_CONNECTION_KEEPALIVE_S,
-)
+from nanomoni.infrastructure.http.http_client import AsyncHttpClient
 
 
 @pytest.mark.asyncio
@@ -40,9 +37,6 @@ async def test_connection_limit_caps_the_owned_pool() -> None:
         connector = client._client.connector
         assert connector is not None
         assert connector.limit == 1
-        # Shorter than the vendor's keep-alive would silently drop the connection
-        # during an idle gap and let another worker accept the replacement.
-        assert connector._keepalive_timeout == DEDICATED_CONNECTION_KEEPALIVE_S
     finally:
         await client.aclose()
 

--- a/tests/unit/test_cpu_affinity.py
+++ b/tests/unit/test_cpu_affinity.py
@@ -1,0 +1,95 @@
+"""Tests for per-process core pinning.
+
+The property that matters is exclusivity: if two vendor workers claimed the same
+core the benchmark would silently run with one core idle and two workers sharing
+another, which looks like a slow protocol rather than a misconfiguration.
+"""
+
+from __future__ import annotations
+
+import os
+from multiprocessing import get_context
+from multiprocessing.queues import Queue
+from multiprocessing.synchronize import Barrier
+from typing import Any, Iterable, List, Optional, Set, Tuple
+
+import pytest
+
+from nanomoni.cpu_affinity import pin_to_own_core
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(os, "sched_setaffinity"),
+    reason="CPU affinity is Linux-only",
+)
+
+
+def _claim(
+    lock_dir: str, allowed: Set[int], results: "Queue[Any]", ready: Barrier
+) -> None:
+    """Claim a core out of ``allowed`` and hold it until every sibling has tried."""
+    os.sched_setaffinity(0, allowed)
+    core = pin_to_own_core(label="test", lock_dir=lock_dir)
+    results.put((core, sorted(os.sched_getaffinity(0))))
+    ready.wait(timeout=30)
+
+
+def _run_claimers(
+    lock_dir: str, allowed: Set[int], count: int
+) -> List[Tuple[Optional[int], List[int]]]:
+    ctx = get_context("fork")
+    results: "Queue[Any]" = ctx.Queue()
+    ready = ctx.Barrier(count)
+    procs = [
+        ctx.Process(target=_claim, args=(lock_dir, allowed, results, ready))
+        for _ in range(count)
+    ]
+    for proc in procs:
+        proc.start()
+    # Drained before joining: a full pipe would deadlock a child inside join().
+    collected = [results.get(timeout=30) for _ in procs]
+    for proc in procs:
+        proc.join(timeout=30)
+    return collected
+
+
+def _sorted_claimed(claims: Iterable[Tuple[Optional[int], List[int]]]) -> List[int]:
+    """Drop unclaimed slots so a missing core shows up as a length mismatch."""
+    return sorted(core for core, _ in claims if core is not None)
+
+
+def _available_cores(count: int) -> Set[int]:
+    cores = sorted(os.sched_getaffinity(0))
+    if len(cores) < count:
+        pytest.skip(f"needs {count} available cores, host offers {len(cores)}")
+    return set(cores[:count])
+
+
+def test_each_process_claims_a_distinct_core(tmp_path: Any) -> None:
+    allowed = _available_cores(3)
+
+    claims = _run_claimers(str(tmp_path), allowed, len(allowed))
+
+    assert _sorted_claimed(claims) == sorted(allowed)
+    for core, affinity in claims:
+        assert affinity == [core]
+
+
+def test_extra_processes_keep_their_inherited_affinity(tmp_path: Any) -> None:
+    allowed = _available_cores(2)
+
+    claims = _run_claimers(str(tmp_path), allowed, len(allowed) + 1)
+
+    unpinned = [affinity for core, affinity in claims if core is None]
+    assert len(unpinned) == 1
+    assert unpinned[0] == sorted(allowed)
+
+
+def test_a_released_core_is_reclaimed(tmp_path: Any) -> None:
+    allowed = _available_cores(2)
+
+    first = _run_claimers(str(tmp_path), allowed, len(allowed))
+    second = _run_claimers(str(tmp_path), allowed, len(allowed))
+
+    assert _sorted_claimed(first) == sorted(allowed)
+    assert _sorted_claimed(second) == sorted(allowed)


### PR DESCRIPTION
## Summary
- Adds `cpu_affinity.pin_to_own_core`: flock-per-core-file scheme so sibling worker/client processes each claim a distinct core.
- Replaces uvicorn's shared-socket multi-worker mode with N independent single-worker servers on consecutive ports (a shared accept socket was piling connections onto a few workers).
- Restructures the benchmark client into N virtual clients, run concurrently and optionally sharded across OS processes, each pinned to one dedicated vendor connection/port.
- `http_client.py`: configurable `connection_limit`, longer keep-alive, one-shot retry on `ServerDisconnectedError`.
- **Breaking env var rename:** `CLIENT_PRIVATE_KEY_PEM` (str) → `CLIENT_PRIVATE_KEY_PEMS` (JSON array), to support one keypair per virtual client.
- `docker-compose.yml`: per-service `cpuset` pinning across the whole stack; named volumes → bind mounts under `.data/` for redis/grafana/prometheus (fixes profile data loss on container recreation for pyroscope, addressed further in PR #3).
- `run_benchmark.sh`: fans traffic out across virtual clients, and flushes vendor Redis between runs.

## Depends on
Stacked on #70 (PayTree Child-Pair / merkle repo refactor).

## Known workaround, not a fix
The `redis-cli flushall` added to `run_benchmark.sh` between runs is a workaround for the open merkle-node/channel/state leak tracked in #70 — nothing currently calls `delete()` on channel close, so without the flush, later sweep iterations inherit every earlier one's data.

## Test plan
- [ ] `poetry run pytest tests/use_cases`
- [ ] `poetry run pytest -m e2e tests/e2e` (all 4 services up)
- [ ] `bash scripts/lint.sh && poetry run mypy src/nanomoni`
- [ ] Manually verify `CLIENT_PRIVATE_KEY_PEMS` migration in any existing env files/secrets before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple virtual clients, configurable process distribution, vendor port allocation, and optional CPU pinning.
  * Multi-worker services can run on dedicated ports with configurable worker affinity.
  * Improved connection pooling, keep-alive behavior, and transient disconnect recovery.
  * Expanded benchmark sweeps and reporting for virtual-client workloads.

* **Documentation**
  * Added guidance on worker affinity, port distribution, saturation limits, benchmarking, and local development.
  * Updated Docker Compose startup and configuration instructions.

* **Tests**
  * Added coverage for worker URL distribution, connection pools, and CPU affinity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->