### PR TITLE
Add CPU profiling + TPS-saturation sweep tooling to bench-plotter

### DIFF
--- a/alloy.config
+++ b/alloy.config
@@ -3,8 +3,17 @@ discovery.docker "local_containers" {
 }
 
 pyroscope.ebpf "instance" {
-  forward_to = [pyroscope.write.endpoint.receiver]
-  targets    = discovery.docker.local_containers.targets
+  forward_to  = [pyroscope.write.endpoint.receiver]
+  targets     = discovery.docker.local_containers.targets
+  // Default is 19/s (confirmed against Alloy's source -- the docs disagree with
+  // themselves, some pages say 97). At 19/s, a sub-millisecond function called
+  // on every request (e.g. the vendor's repository save/get calls) only gets
+  // ~1 sample per 250-380 requests, so the per-mode db/crypto/other CPU-time
+  // splits bench-plotter's profile_macro_micro.png draws from it are built
+  // from a few dozen to ~100 raw samples each -- noisy enough that a 20-40%
+  // swing between modes is indistinguishable from sampling variance. 97/s
+  // roughly quintuples that sample count for the same run duration.
+  sample_rate = 97
 }
 
 pyroscope.write "endpoint" {

--- a/bench-plotter/src/bench_plotter/draw_worker.py
+++ b/bench-plotter/src/bench_plotter/draw_worker.py
@@ -31,7 +31,17 @@ from bench_plotter.plotting.distribution_renderers import (
     create_precomputed_boxplot,
     create_bucket_ecdf,
 )
-from bench_plotter.plotting.sweep_renderers import create_sweep_line_plot
+from bench_plotter.plotting.sweep_renderers import (
+    create_delta_table,
+    create_identity_comparison_plot,
+    create_sweep_line_plot,
+)
+from bench_plotter.plotting.flame_renderer import create_flame_graph
+from bench_plotter.plotting.profile_bar_renderer import (
+    create_macro_micro_bar,
+    create_macro_micro_table,
+)
+from bench_plotter.plotting.table_renderer import create_stats_table
 
 # Stable string names -> existing draw functions. The names are the contract
 # stored in ``DrawTask.fn_name``; the plan/transform stages emit these and the
@@ -45,6 +55,12 @@ DRAW_REGISTRY: Dict[str, Callable[..., None]] = {
     "precomputed_box": create_precomputed_boxplot,
     "bucket_ecdf": create_bucket_ecdf,
     "sweep_line": create_sweep_line_plot,
+    "identity_comparison": create_identity_comparison_plot,
+    "delta_table": create_delta_table,
+    "stats_table": create_stats_table,
+    "flame_graph": create_flame_graph,
+    "profile_macro_micro_bar": create_macro_micro_bar,
+    "profile_macro_micro_table": create_macro_micro_table,
 }
 
 

--- a/bench-plotter/src/bench_plotter/flamebearer.py
+++ b/bench-plotter/src/bench_plotter/flamebearer.py
@@ -1,0 +1,205 @@
+"""Parse Pyroscope "flamebearer" payloads into a call tree and sum CPU time by
+function name.
+
+Flamebearer format: ``flamebearer["levels"][depth]`` is a flat array of 4-tuples
+``(x_offset_delta, total_ticks, self_ticks, name_index)`` per node, ordered
+left-to-right; ``x_offset_delta`` is relative to the end of the previous
+sibling at that depth. ``flamebearer["names"][name_index]`` is the symbol.
+``metadata.sampleRate`` converts ticks to seconds (``seconds = ticks /
+sampleRate``); for the ``process_cpu:...:nanoseconds`` profile type,
+``sampleRate`` is ``1_000_000_000`` and ticks are literally nanoseconds.
+
+The same function name can appear as both an ancestor and a descendant of
+itself in one call path (confirmed live: a router-level ``receive_payment``
+directly wraps a use-case ``receive_payment``). A node's ``total_ticks``
+already includes its descendants', so naively summing every node with a given
+name double-counts that case. ``sum_ticks_by_name``/``sum_ticks_within`` only
+count the **outermost** occurrence of a name along each root-to-leaf path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, Iterable, List, NamedTuple, Tuple
+
+
+@dataclass
+class FlameNode:
+    name: str
+    total_ticks: int
+    self_ticks: int
+    start: int
+    end: int
+    children: List["FlameNode"] = field(default_factory=list)
+
+
+class _RawNode(NamedTuple):
+    start: int
+    end: int
+    total: int
+    self_ticks: int
+    name_idx: int
+
+
+def _parse_level(raw: List[int]) -> List[_RawNode]:
+    nodes: List[_RawNode] = []
+    x = 0
+    for i in range(0, len(raw), 4):
+        x += raw[i]
+        total, self_ticks, name_idx = raw[i + 1], raw[i + 2], raw[i + 3]
+        nodes.append(_RawNode(x, x + total, total, self_ticks, name_idx))
+        x += total
+    return nodes
+
+
+def build_tree(payload: Dict[str, Any]) -> FlameNode:
+    """Reconstruct the call tree from a flamebearer payload's flat levels."""
+    fb = payload["flamebearer"]
+    names = fb["names"]
+    levels = fb["levels"]
+    if not levels or not levels[0]:
+        raise ValueError("empty flamebearer: no levels")
+
+    def to_node(rn: _RawNode) -> FlameNode:
+        return FlameNode(
+            name=names[rn.name_idx],
+            total_ticks=rn.total,
+            self_ticks=rn.self_ticks,
+            start=rn.start,
+            end=rn.end,
+        )
+
+    root_raw = _parse_level(levels[0])[0]
+    root = to_node(root_raw)
+    current_level = [root]
+    for depth in range(1, len(levels)):
+        raw_nodes = _parse_level(levels[depth])
+        built = [to_node(rn) for rn in raw_nodes]
+        parent_idx = 0
+        for child in built:
+            while (
+                parent_idx < len(current_level) - 1
+                and current_level[parent_idx].end <= child.start
+            ):
+                parent_idx += 1
+            current_level[parent_idx].children.append(child)
+        current_level = built
+    return root
+
+
+def iter_levels(
+    payload: Dict[str, Any],
+) -> List[List[Tuple[int, int, int, int, str]]]:
+    """Per-depth list of ``(start, end, total_ticks, self_ticks, name)`` spans.
+
+    For consumers (e.g. the flame-graph renderer) that only need each row's
+    horizontal extent and resolved name, not the linked :class:`FlameNode` tree.
+    """
+    fb = payload["flamebearer"]
+    names = fb["names"]
+    return [
+        [
+            (rn.start, rn.end, rn.total, rn.self_ticks, names[rn.name_idx])
+            for rn in _parse_level(level)
+        ]
+        for level in fb["levels"]
+    ]
+
+
+def sample_rate(payload: Dict[str, Any]) -> float:
+    return float(payload["metadata"]["sampleRate"])
+
+
+def root_total_ticks(payload: Dict[str, Any]) -> int:
+    return int(payload["flamebearer"]["levels"][0][1])
+
+
+def _sum_outermost(roots: Iterable[FlameNode], names: Iterable[str]) -> Dict[str, int]:
+    target = set(names)
+    totals: Dict[str, int] = {n: 0 for n in target}
+
+    def walk(node: FlameNode, closed: FrozenSet[str]) -> None:
+        if node.name in target and node.name not in closed:
+            totals[node.name] += node.total_ticks
+            closed = closed | {node.name}
+        for child in node.children:
+            walk(child, closed)
+
+    for root in roots:
+        walk(root, frozenset())
+    return totals
+
+
+def outermost_nodes(root: FlameNode, name: str) -> List[FlameNode]:
+    """Nodes named ``name``, never descending into an already-matched node's subtree."""
+    result: List[FlameNode] = []
+
+    def walk(node: FlameNode) -> None:
+        if node.name == name:
+            result.append(node)
+            return
+        for child in node.children:
+            walk(child)
+
+    walk(root)
+    return result
+
+
+def sum_ticks_by_name(root: FlameNode, names: Iterable[str]) -> Dict[str, int]:
+    """Sum ticks of the outermost occurrence of each target name in the whole tree."""
+    return _sum_outermost([root], names)
+
+
+def sum_ticks_within(nodes: List[FlameNode], names: Iterable[str]) -> Dict[str, int]:
+    """Same as :func:`sum_ticks_by_name`, scoped to the given subtrees only."""
+    return _sum_outermost(nodes, names)
+
+
+def focus_on(
+    payload: Dict[str, Any], name: str
+) -> Tuple[List[List[Tuple[int, int, int, int, str]]], int]:
+    """Re-root the call tree at every outermost occurrence of ``name``.
+
+    A full process flame graph spends most of its depth on framework/event-loop
+    frames before ever reaching the interesting handler code, so cropping to
+    just the subtree(s) under a given function (e.g. ``run_endpoint_function``)
+    makes the graph legible. Each occurrence (one per request handled in the
+    window) is tiled left-to-right starting at depth 0, in the same
+    ``(start, end, total_ticks, self_ticks, name)`` row shape :func:`iter_levels`
+    returns, so the flame-graph renderer needs no separate code path.
+
+    Returns ``([], 0)`` if ``name`` doesn't occur in this profile.
+    """
+    root = build_tree(payload)
+    occurrences = outermost_nodes(root, name)
+    if not occurrences:
+        return [], 0
+
+    rows_by_depth: Dict[int, List[Tuple[int, int, int, int, str]]] = {}
+    cursor = 0
+    for occurrence in occurrences:
+        shift = cursor - occurrence.start
+
+        def collect(node: FlameNode, depth: int) -> None:
+            rows_by_depth.setdefault(depth, []).append(
+                (
+                    node.start + shift,
+                    node.end + shift,
+                    node.total_ticks,
+                    node.self_ticks,
+                    node.name,
+                )
+            )
+            for child in node.children:
+                collect(child, depth + 1)
+
+        collect(occurrence, 0)
+        cursor += occurrence.total_ticks
+
+    max_depth = max(rows_by_depth)
+    levels = [
+        sorted(rows_by_depth.get(depth, []), key=lambda r: r[0])
+        for depth in range(max_depth + 1)
+    ]
+    total_ticks = sum(o.total_ticks for o in occurrences)
+    return levels, total_ticks

--- a/bench-plotter/src/bench_plotter/io_utils.py
+++ b/bench-plotter/src/bench_plotter/io_utils.py
@@ -3,10 +3,48 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def load_json_data(file_path: str) -> Any:
     """Load JSON data from file (may be a dict, list, or scalar)."""
     with open(file_path, "r") as f:
         return json.load(f)
+
+
+def load_timing_file(path: str) -> Tuple[str, List[Dict[str, Any]]]:
+    """Return ``(server_run_timestamp, runs)`` from a benchmark timing file.
+
+    Accepts the sweep object shape (``{server_run_timestamp, runs}``) or a legacy
+    bare list, in which case the timestamp is derived from ``now``. Shared by the
+    sweep and saturation runners, which both consume the same file.
+    """
+    data = load_json_data(path)
+    fallback_ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    if isinstance(data, dict):
+        ts = data.get("server_run_timestamp") or fallback_ts
+        runs = data.get("runs", [])
+        if not isinstance(runs, list):
+            runs = []
+        return str(ts), [r for r in runs if isinstance(r, dict)]
+    if isinstance(data, list):
+        return fallback_ts, [r for r in data if isinstance(r, dict)]
+    return fallback_ts, []
+
+
+def load_virtual_clients(path: str) -> Optional[int]:
+    """Return the ``virtual_clients`` field from a timing file, if present.
+
+    Sweeps record how many in-process virtual clients drove each run (see
+    ``CLIENT_VIRTUAL_CLIENTS`` in ``run_tps_saturation_sweep.sh``); charts read
+    it back to label the test configuration instead of leaving the reader to
+    guess the concurrency behind the numbers. Legacy timing files (a bare list,
+    or an object without this field) have no such record.
+    """
+    data = load_json_data(path)
+    if isinstance(data, dict):
+        value = data.get("virtual_clients")
+        if isinstance(value, int):
+            return value
+    return None

--- a/bench-plotter/src/bench_plotter/metric_queries/__init__.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/__init__.py
@@ -3,16 +3,30 @@
 from typing import Any, Dict, Iterable, List
 
 from .common import get_common_charts
-from .signature import get_signature_charts, LATENCY_BUCKET_METRIC as _SIGNATURE_METRIC
-from .payword import get_payword_charts, LATENCY_BUCKET_METRIC as _PAYWORD_METRIC
-from .paytree import get_paytree_charts, LATENCY_BUCKET_METRIC as _PAYTREE_METRIC
+from .signature import (
+    get_signature_charts,
+    LATENCY_BUCKET_METRIC as _SIGNATURE_METRIC,
+    PAYMENT_COUNTER_METRIC as _SIGNATURE_COUNTER,
+)
+from .payword import (
+    get_payword_charts,
+    LATENCY_BUCKET_METRIC as _PAYWORD_METRIC,
+    PAYMENT_COUNTER_METRIC as _PAYWORD_COUNTER,
+)
+from .paytree import (
+    get_paytree_charts,
+    LATENCY_BUCKET_METRIC as _PAYTREE_METRIC,
+    PAYMENT_COUNTER_METRIC as _PAYTREE_COUNTER,
+)
 from .paytree_first_opt import (
     get_paytree_first_opt_charts,
     LATENCY_BUCKET_METRIC as _PAYTREE_FIRST_OPT_METRIC,
+    PAYMENT_COUNTER_METRIC as _PAYTREE_FIRST_OPT_COUNTER,
 )
 from .paytree_child_pair import (
     get_paytree_child_pair_charts,
     LATENCY_BUCKET_METRIC as _PAYTREE_CHILD_PAIR_METRIC,
+    PAYMENT_COUNTER_METRIC as _PAYTREE_CHILD_PAIR_COUNTER,
 )
 
 # Single source of truth for mode -> latency-histogram bucket metric name,
@@ -24,6 +38,16 @@ LATENCY_BUCKET_METRIC_BY_MODE: Dict[str, str] = {
     "paytree": _PAYTREE_METRIC,
     "paytree_first_opt": _PAYTREE_FIRST_OPT_METRIC,
     "paytree_child_pair": _PAYTREE_CHILD_PAIR_METRIC,
+}
+
+# mode -> success-counter metric name, consumed by saturation/aggregate.py to
+# build the achieved-TPS query for whichever modes a sweep actually ran.
+PAYMENT_COUNTER_METRIC_BY_MODE: Dict[str, str] = {
+    "signature": _SIGNATURE_COUNTER,
+    "payword": _PAYWORD_COUNTER,
+    "paytree": _PAYTREE_COUNTER,
+    "paytree_first_opt": _PAYTREE_FIRST_OPT_COUNTER,
+    "paytree_child_pair": _PAYTREE_CHILD_PAIR_COUNTER,
 }
 
 # mode -> chart getter: the one place that knows how to turn a mode name into

--- a/bench-plotter/src/bench_plotter/metric_queries/common.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/common.py
@@ -10,11 +10,11 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "issuer_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Input",
             },
             {
-                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Output",
             },
         ],
@@ -34,7 +34,7 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "issuer_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[30s])\n)',
+                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="issuer",\n    image!=""\n  }[1m])\n)',
                 "legend": "__auto",
             }
         ],
@@ -54,7 +54,7 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "issuer_resources",
         "queries": [
             {
-                "promql": 'rate(container_cpu_usage_seconds_total{job="cadvisor", name="nanomoni-redis-issuer-1", image!=""}[30s])',
+                "promql": 'rate(container_cpu_usage_seconds_total{job="cadvisor", name="nanomoni-redis-issuer-1", image!=""}[1m])',
                 "legend": "Redis Issuer CPU",
             }
         ],
@@ -64,11 +64,11 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "client_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Input",
             },
             {
-                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Output",
             },
         ],
@@ -88,7 +88,7 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "client_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[30s])\n)',
+                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="client",\n    image!=""\n  }[1m])\n)',
                 "legend": "__auto",
             }
         ],
@@ -98,11 +98,11 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "vendor_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_receive_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Input",
             },
             {
-                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[30s])\n) / 1024',
+                "promql": 'sum(\n  rate(container_network_transmit_bytes_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[1m])\n) / 1024',
                 "legend": "Output",
             },
         ],
@@ -122,7 +122,7 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "vendor_resources",
         "queries": [
             {
-                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[30s])\n)',
+                "promql": 'sum(\n  rate(container_cpu_usage_seconds_total{\n    job="cadvisor",\n    container_label_com_docker_compose_service="vendor",\n    image!=""\n  }[1m])\n)',
                 "legend": "__auto",
             }
         ],
@@ -142,7 +142,7 @@ COMMON_CHARTS: List[Dict[str, Any]] = [
         "section": "vendor_resources",
         "queries": [
             {
-                "promql": 'rate(container_cpu_usage_seconds_total{job="cadvisor", name="nanomoni-redis-vendor-1", image!=""}[30s])',
+                "promql": 'rate(container_cpu_usage_seconds_total{job="cadvisor", name="nanomoni-redis-vendor-1", image!=""}[1m])',
                 "legend": "Redis Vendor CPU",
             }
         ],

--- a/bench-plotter/src/bench_plotter/metric_queries/paytree.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/paytree.py
@@ -8,6 +8,10 @@ from typing import Any, Dict, List
 # queries instead of duplicating the string there.
 LATENCY_BUCKET_METRIC = "paytree_std_payment_request_duration_milliseconds_bucket"
 
+# Single source of truth for this mode's payment counter, consumed by
+# saturation/aggregate.py to build the achieved-TPS query.
+PAYMENT_COUNTER_METRIC = "paytree_std_payment_requests_total"
+
 # Paytree-specific TPS metrics charts
 PAYTREE_CHARTS: List[Dict[str, Any]] = [
     {
@@ -15,7 +19,7 @@ PAYTREE_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": 'rate(paytree_std_payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "promql": f'rate({PAYMENT_COUNTER_METRIC}{{job="vendor-api", status="success"}}[10s])',
                 "legend": "Paytree",
             },
         ],
@@ -25,15 +29,15 @@ PAYTREE_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree P99",
             },
             {
-                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree P95",
             },
             {
-                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree P50",
             },
         ],

--- a/bench-plotter/src/bench_plotter/metric_queries/paytree_child_pair.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/paytree_child_pair.py
@@ -10,6 +10,10 @@ LATENCY_BUCKET_METRIC = (
     "paytree_child_pair_payment_request_duration_milliseconds_bucket"
 )
 
+# Single source of truth for this mode's payment counter, consumed by
+# saturation/aggregate.py to build the achieved-TPS query.
+PAYMENT_COUNTER_METRIC = "paytree_child_pair_payment_requests_total"
+
 # Paytree-child-pair-specific TPS metrics charts
 PAYTREE_CHILD_PAIR_CHARTS: List[Dict[str, Any]] = [
     {
@@ -17,7 +21,7 @@ PAYTREE_CHILD_PAIR_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": 'rate(paytree_child_pair_payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "promql": f'rate({PAYMENT_COUNTER_METRIC}{{job="vendor-api", status="success"}}[10s])',
                 "legend": "Paytree Child-Pair",
             },
         ],
@@ -27,15 +31,15 @@ PAYTREE_CHILD_PAIR_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree Child-Pair P99",
             },
             {
-                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree Child-Pair P95",
             },
             {
-                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree Child-Pair P50",
             },
         ],

--- a/bench-plotter/src/bench_plotter/metric_queries/paytree_first_opt.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/paytree_first_opt.py
@@ -8,6 +8,10 @@ from typing import Any, Dict, List
 # queries instead of duplicating the string there.
 LATENCY_BUCKET_METRIC = "paytree_first_opt_payment_request_duration_milliseconds_bucket"
 
+# Single source of truth for this mode's payment counter, consumed by
+# saturation/aggregate.py to build the achieved-TPS query.
+PAYMENT_COUNTER_METRIC = "paytree_first_opt_payment_requests_total"
+
 # Paytree-first-opt-specific TPS metrics charts
 PAYTREE_FIRST_OPT_CHARTS: List[Dict[str, Any]] = [
     {
@@ -15,7 +19,7 @@ PAYTREE_FIRST_OPT_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": 'rate(paytree_first_opt_payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "promql": f'rate({PAYMENT_COUNTER_METRIC}{{job="vendor-api", status="success"}}[10s])',
                 "legend": "Paytree First-Opt",
             },
         ],
@@ -25,15 +29,15 @@ PAYTREE_FIRST_OPT_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree First-Opt P99",
             },
             {
-                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree First-Opt P95",
             },
             {
-                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Paytree First-Opt P50",
             },
         ],

--- a/bench-plotter/src/bench_plotter/metric_queries/payword.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/payword.py
@@ -8,6 +8,10 @@ from typing import Any, Dict, List
 # queries instead of duplicating the string there.
 LATENCY_BUCKET_METRIC = "payword_payment_request_duration_milliseconds_bucket"
 
+# Single source of truth for this mode's payment counter, consumed by
+# saturation/aggregate.py to build the achieved-TPS query.
+PAYMENT_COUNTER_METRIC = "payword_payment_requests_total"
+
 # Payword-specific TPS metrics charts
 PAYWORD_CHARTS: List[Dict[str, Any]] = [
     {
@@ -15,7 +19,7 @@ PAYWORD_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": 'rate(payword_payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "promql": f'rate({PAYMENT_COUNTER_METRIC}{{job="vendor-api", status="success"}}[10s])',
                 "legend": "Payword",
             },
         ],
@@ -25,15 +29,15 @@ PAYWORD_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payword P99",
             },
             {
-                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payword P95",
             },
             {
-                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payword P50",
             },
         ],

--- a/bench-plotter/src/bench_plotter/metric_queries/signature.py
+++ b/bench-plotter/src/bench_plotter/metric_queries/signature.py
@@ -8,6 +8,10 @@ from typing import Any, Dict, List
 # queries instead of duplicating the string there.
 LATENCY_BUCKET_METRIC = "payment_request_duration_milliseconds_bucket"
 
+# Single source of truth for this mode's payment counter, consumed by
+# saturation/aggregate.py to build the achieved-TPS query.
+PAYMENT_COUNTER_METRIC = "payment_requests_total"
+
 # Signature-specific TPS metrics charts
 SIGNATURE_CHARTS: List[Dict[str, Any]] = [
     {
@@ -15,7 +19,7 @@ SIGNATURE_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": 'rate(payment_requests_total{job="vendor-api", status="success"}[30s])',
+                "promql": f'rate({PAYMENT_COUNTER_METRIC}{{job="vendor-api", status="success"}}[10s])',
                 "legend": "Payment Requests",
             },
         ],
@@ -25,15 +29,15 @@ SIGNATURE_CHARTS: List[Dict[str, Any]] = [
         "section": "tps_metrics",
         "queries": [
             {
-                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.99, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payment P99",
             },
             {
-                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.95, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payment P95",
             },
             {
-                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[30s])) by (le))',
+                "promql": f'histogram_quantile(0.50, sum(rate({LATENCY_BUCKET_METRIC}{{job="vendor-api", status="success"}}[10s])) by (le))',
                 "legend": "Payment P50",
             },
         ],

--- a/bench-plotter/src/bench_plotter/mode_style.py
+++ b/bench-plotter/src/bench_plotter/mode_style.py
@@ -1,0 +1,69 @@
+"""Shared per-payment-mode visual identity and vs-TPS series grouping.
+
+Extracted from ``sweep/aggregate.py`` so both it and ``profiling/aggregate.py``
+can build "one line per mode" vs-TPS charts with the same stable
+color/marker assignment, without either module depending on the other
+(``sweep`` already depends on ``profiling`` for the profiling stage, so the
+reverse edge would be circular).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from bench_plotter.plotting.common import PALETTE
+
+# Stable visual identity per payment mode (sorted-mode index into the palette).
+MODE_MARKERS = ("o", "s", "^", "D", "v", "P", "X", "*")
+KNOWN_MODES = (
+    "paytree",
+    "paytree_first_opt",
+    "paytree_child_pair",
+    "payword",
+    "signature",
+)
+
+
+def mode_style(mode: str) -> Dict[str, str]:
+    """Return ``{color, marker}`` for a payment mode (stable across charts)."""
+    try:
+        idx = KNOWN_MODES.index(mode)
+    except ValueError:
+        idx = abs(hash(mode)) % len(PALETTE)
+    return {
+        "color": PALETTE[idx % len(PALETTE)],
+        "marker": MODE_MARKERS[idx % len(MODE_MARKERS)],
+    }
+
+
+def series_by_mode(
+    scalars: List[Dict[str, Any]],
+    y_key: str,
+    label_suffix: str = "",
+    linestyle: str = "-",
+) -> List[Dict[str, Any]]:
+    """Group (tps, y) points by mode for one y-field, with stable mode styling."""
+    by_mode: Dict[str, List[Tuple[float, float]]] = {}
+    for row in scalars:
+        y = row.get(y_key)
+        if y is None:
+            continue
+        mode = row["mode"]
+        by_mode.setdefault(mode, []).append((row["tps"], float(y)))
+
+    series: List[Dict[str, Any]] = []
+    for mode in sorted(by_mode):
+        points = sorted(by_mode[mode], key=lambda p: p[0])
+        label = f"{mode}{label_suffix}" if label_suffix else mode
+        style = mode_style(mode)
+        series.append(
+            {
+                "label": label,
+                "x_values": [p[0] for p in points],
+                "y_values": [p[1] for p in points],
+                "color": style["color"],
+                "marker": style["marker"],
+                "linestyle": linestyle,
+            }
+        )
+    return series

--- a/bench-plotter/src/bench_plotter/pipeline/latency.py
+++ b/bench-plotter/src/bench_plotter/pipeline/latency.py
@@ -21,12 +21,12 @@ _QUANTILES = [0.05, 0.25, 0.50, 0.75, 0.95]
 def _box_expr(metric: str, q: float) -> str:
     return (
         f"histogram_quantile({q}, sum(rate("
-        f'{metric}{{job="vendor-api", status="success"}}[30s])) by (le))'
+        f'{metric}{{job="vendor-api", status="success"}}[10s])) by (le))'
     )
 
 
 def _dist_expr(metric: str) -> str:
-    return f'sum(rate({metric}{{job="vendor-api", status="success"}}[30s])) by (le)'
+    return f'sum(rate({metric}{{job="vendor-api", status="success"}}[10s])) by (le)'
 
 
 def build_latency_jobs(
@@ -87,6 +87,10 @@ def build_latency_jobs(
                     "entries": dist_entries,
                     "ecdf_path": str(tps_dir / "vendor_payment_latency_ecdf.png"),
                     "violin_path": str(tps_dir / "vendor_payment_latency_violin.png"),
+                    # The box plot's five quantiles say nothing about the mean or
+                    # the spread around it; both come off the same buckets these
+                    # distribution figures are built from.
+                    "stats_path": str(tps_dir / "vendor_payment_latency_stats.png"),
                 },
             )
         )

--- a/bench-plotter/src/bench_plotter/pipeline/latency_transform.py
+++ b/bench-plotter/src/bench_plotter/pipeline/latency_transform.py
@@ -10,9 +10,15 @@ from typing import Any, Dict, List
 
 from bench_plotter.prometheus_matrix import matrix_to_per_series_charts
 from bench_plotter.plotting.windowing import steady_state_samples
-from bench_plotter.plotting.histogram_math import histogram_to_samples
+from bench_plotter.plotting.histogram_math import (
+    histogram_moments,
+    histogram_quantile,
+    histogram_to_samples,
+)
 
 from .model import DrawTask, PlotJob, ResultCache
+
+_STATS_COLUMNS = ("mode", "mean_ms", "stddev_ms", "p50_ms", "p95_ms")
 
 
 def _le_sort_key(le: str) -> float:
@@ -162,4 +168,45 @@ def transform_latency_dist(job: PlotJob, cache: ResultCache) -> List[DrawTask]:
             },
         )
     )
+    stats_rows = _stats_rows(dists)
+    if stats_rows:
+        tasks.append(
+            DrawTask(
+                fn_name="stats_table",
+                output_path=job.params["stats_path"],
+                kwargs={
+                    "col_labels": list(_STATS_COLUMNS),
+                    "rows": stats_rows,
+                    "title": (
+                        "Vendor Payment Latency (steady-state, "
+                        "estimated from histogram buckets)"
+                    ),
+                },
+            )
+        )
     return tasks
+
+
+def _stats_rows(dists: List[Dict[str, Any]]) -> List[List[Any]]:
+    """Per-mode mean/stddev/p50/p95 rows from the bucket distributions.
+
+    All four come from the same bucket CDF so they stay mutually consistent; that
+    makes them bucket-resolution estimates, so the p50 here can differ slightly
+    from the box plot's, which Prometheus computes server-side.
+    """
+    rows: List[List[Any]] = []
+    for dist in dists:
+        edges, cumulative = dist["edges"], dist["cum_fraction"]
+        mean, stddev = histogram_moments(edges, cumulative)
+        if mean is None:
+            continue
+        rows.append(
+            [
+                dist["label"],
+                mean,
+                stddev,
+                histogram_quantile(edges, cumulative, 0.50),
+                histogram_quantile(edges, cumulative, 0.95),
+            ]
+        )
+    return rows

--- a/bench-plotter/src/bench_plotter/pipeline/per_payment_table_transform.py
+++ b/bench-plotter/src/bench_plotter/pipeline/per_payment_table_transform.py
@@ -1,0 +1,71 @@
+"""Transform stage for the client-egress-per-payment table.
+
+Turns the client's steady-state egress *rate* into a *size*: dividing KiB/s by
+the payments/s that produced it leaves the bytes one payment request puts on the
+wire, which is the number to compare across payment modes (a mode whose proof
+grows with the payment index costs bandwidth the KiB/s chart only shows
+indirectly, mixed together with the load level). Plan-side job construction
+lives in :mod:`.resource`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+from bench_plotter.plotting.windowing import steady_state_samples
+
+from .model import DrawTask, PlotJob, ResultCache
+from .series_runs import runs_from_series
+
+_COLUMNS = (
+    "mode",
+    "target_tps",
+    "egress_kib_s_mean",
+    "kib_per_payment",
+    "bytes_per_payment",
+)
+
+_BYTES_PER_KIB = 1024.0
+
+
+def transform_per_payment_table(job: PlotJob, cache: ResultCache) -> List[DrawTask]:
+    """Build the per-payment request-size table from a cached rate series."""
+    runs = runs_from_series(job.params["series"], cache)
+    tps_by_mode: Dict[str, Any] = job.params["tps_by_mode"]
+
+    rows: List[List[Any]] = []
+    for run in runs:
+        mode = run["interval_mode"]
+        tps = tps_by_mode.get(mode)
+        samples = steady_state_samples(run["values"])
+        if not tps or not samples:
+            continue
+        kib_per_second = float(np.mean(samples))
+        kib_per_payment = kib_per_second / float(tps)
+        rows.append(
+            [
+                mode,
+                float(tps),
+                kib_per_second,
+                kib_per_payment,
+                kib_per_payment * _BYTES_PER_KIB,
+            ]
+        )
+
+    if not rows:
+        print(f"No steady-state samples for per-payment table: {job.title}")
+        return []
+    rows.sort(key=lambda row: str(row[0]))
+    return [
+        DrawTask(
+            fn_name="stats_table",
+            output_path=job.output_path,
+            kwargs={
+                "col_labels": list(_COLUMNS),
+                "rows": rows,
+                "title": job.title,
+            },
+        )
+    ]

--- a/bench-plotter/src/bench_plotter/pipeline/resource.py
+++ b/bench-plotter/src/bench_plotter/pipeline/resource.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from .model import PlotJob
 from .plan_common import legend_and_names, overlay_job, specs_for
@@ -17,6 +17,12 @@ _STEADY_STATE_PREFIXES = (
     "Client CPU Usage",
     "Client Network",
 )
+
+# The one target whose steady-state rate, divided by the payment rate that drove
+# it, is a meaningful per-payment quantity: what the client transmits is the
+# payment requests themselves, so KiB/s over payments/s is the average request
+# size on the wire.
+_PER_PAYMENT_TARGET = ("Client Network (KiB/s)", "Output")
 
 
 def build_resource_jobs(
@@ -76,4 +82,45 @@ def build_resource_jobs(
                         },
                     )
                 )
+            if (title, legend_format) == _PER_PAYMENT_TARGET:
+                job = _per_payment_job(
+                    output_path=str(section_dir / f"{stem}_per_payment.png"),
+                    section=section,
+                    series=series,
+                    resolved=resolved,
+                    intervals=intervals,
+                )
+                if job is not None:
+                    jobs.append(job)
     return jobs
+
+
+def _per_payment_job(
+    *,
+    output_path: str,
+    section: str,
+    series: List[Dict[str, Any]],
+    resolved: List[Dict[str, Any]],
+    intervals: List[Dict[str, Any]],
+) -> Optional[PlotJob]:
+    """The per-payment request-size job, or ``None`` without a payment rate.
+
+    Needs each interval's ``tps`` to divide by; callers that build a plan from
+    intervals lacking it (the pipeline is usable standalone, not only from a
+    sweep) simply get no such job rather than a table of blanks.
+    """
+    tps_by_mode = {
+        iv["mode"]: float(iv["tps"])
+        for iv in intervals
+        if iv.get("mode") and iv.get("tps")
+    }
+    if not tps_by_mode:
+        return None
+    return PlotJob(
+        kind="per_payment_table",
+        title="Client egress per payment (steady-state mean / target TPS)",
+        output_path=output_path,
+        section=section,
+        specs=[r["spec"] for r in resolved],
+        params={"series": series, "tps_by_mode": tps_by_mode},
+    )

--- a/bench-plotter/src/bench_plotter/pipeline/transform.py
+++ b/bench-plotter/src/bench_plotter/pipeline/transform.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 from .model import DrawTask, PlotJob, ResultCache
 from .series_runs import runs_from_series
 from .latency_transform import transform_latency_box, transform_latency_dist
+from .per_payment_table_transform import transform_per_payment_table
 from .steady_state_transform import transform_steady_state
 
 
@@ -59,6 +60,7 @@ _DISPATCH = {
     "steady_state": transform_steady_state,
     "latency_box": transform_latency_box,
     "latency_dist": transform_latency_dist,
+    "per_payment_table": transform_per_payment_table,
 }
 
 

--- a/bench-plotter/src/bench_plotter/plotting/distribution_renderers.py
+++ b/bench-plotter/src/bench_plotter/plotting/distribution_renderers.py
@@ -36,7 +36,9 @@ def create_steady_state_boxplot(
         print(f"No steady-state samples for box plot: {title}")
         return
 
-    fig, ax = plt.subplots(figsize=(8, 6))
+    # Long mode names (e.g. "paytree_first_opt") collide at a fixed width once
+    # there are more than a handful of boxes, so scale width with box count.
+    fig, ax = plt.subplots(figsize=(max(8, 1.8 * len(data)), 6))
     positions = list(range(1, len(data) + 1))
     # Fliers are omitted: with the low variance typical of these metrics the IQR
     # is tiny, so most points render as fliers even though they aren't anomalies.
@@ -72,7 +74,7 @@ def create_precomputed_boxplot(
     if not stats:
         print(f"No stats for box plot: {title}")
         return
-    fig, ax = plt.subplots(figsize=(8, 6))
+    fig, ax = plt.subplots(figsize=(max(8, 1.8 * len(stats)), 6))
     ax.bxp(stats, showfliers=False)
     ax.set_xticks(list(range(1, len(stats) + 1)))
     ax.set_xticklabels([f"{s.get('label', '')}\nmed {s['med']:.3g}" for s in stats])

--- a/bench-plotter/src/bench_plotter/plotting/flame_renderer.py
+++ b/bench-plotter/src/bench_plotter/plotting/flame_renderer.py
@@ -1,0 +1,188 @@
+"""Render a Pyroscope flamebearer as a static icicle-style flame graph.
+
+Pyroscope's own ``/render?format=png`` is not implemented by the deployed
+server version (confirmed live: it silently falls back to JSON), so the image
+is built here with matplotlib -- one horizontal row per call-tree depth via
+``ax.broken_barh``, root at the top. Frames matching a target function name
+(crypto / db read / db write / serialize, per mode -- see
+``profiling.mode_functions``)
+are colored to match the aggregate macro/micro bar chart's legend; everything
+else is neutral grey. Labels are skipped on frames narrower than a fixed
+fraction of the total width, the standard flamegraph convention -- a real
+trace has ~900 distinct names and would be unreadable fully labeled.
+
+By default the graph is cropped to the target function's subtree(s) (one per
+request handled in the profiled window, tiled left-to-right) via
+``flamebearer.focus_on`` -- the full process stack spends ~25 levels on
+event-loop/syscall frames before ever reaching the handler code, which leaves
+almost no room for the part anyone actually wants to read.
+
+The axes is placed with ``fig.add_axes`` (fixed figure-fraction rect) rather
+than ``plt.subplots``: ``save_figure()`` unconditionally calls
+``fig.tight_layout()`` before saving, which recomputes subplot spacing and
+undoes any manual title/legend placement above a `plt.subplots` axes -- axes
+added via ``add_axes`` are left untouched by ``tight_layout`` (confirmed:
+it emits a "not compatible" warning and skips them), which is what makes a
+fixed top strip for the title + horizontal legend hold regardless of how
+short the cropped graph is.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, Optional
+
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+from bench_plotter.flamebearer import (
+    focus_on,
+    iter_levels,
+    root_total_ticks,
+    sample_rate,
+)
+
+from .common import save_figure
+from .profile_bar_renderer import (
+    _CRYPTO_COLOR,
+    _DB_READ_COLOR,
+    _DB_WRITE_COLOR,
+    _SERIALIZE_COLOR,
+)
+
+_OTHER_COLOR = "#cfcfcf"
+_MIN_LABEL_FRACTION = 0.006
+_ROW_HEIGHT_IN = 0.16
+DEFAULT_FOCUS = "run_endpoint_function"
+
+# Fixed absolute margins (inches) reserved above/below the plot for the
+# title+legend and the x-axis label, independent of fig_height -- this is
+# what keeps them from colliding on a short (heavily cropped) graph.
+_TOP_MARGIN_IN = 1.0
+_BOTTOM_MARGIN_IN = 0.5
+_SIDE_MARGIN_IN = 0.3
+
+
+def create_flame_graph(
+    flamebearer_payload: Dict[str, Any],
+    title: str = "Flame graph",
+    output_path: str = "flame.png",
+    highlight: Optional[Dict[str, str]] = None,
+    focus: Optional[str] = DEFAULT_FOCUS,
+) -> None:
+    """Draw one flame graph PNG from a Pyroscope flamebearer payload.
+
+    ``highlight`` maps a function name to a hex color (crypto/db/serialize
+    functions for the mode this profile belongs to); unmatched frames render
+    neutral grey.
+    ``focus`` (default ``"run_endpoint_function"``) crops the graph to that
+    function's outermost occurrence(s) instead of rendering the full process
+    stack; pass ``None`` to render the whole tree from the true root.
+    """
+    try:
+        rate = sample_rate(flamebearer_payload)
+        if focus:
+            levels, total_ticks = focus_on(flamebearer_payload, focus)
+            if not levels:
+                print(f"'{focus}' not found in this profile; skipping: {title}")
+                return
+        else:
+            levels = iter_levels(flamebearer_payload)
+            total_ticks = root_total_ticks(flamebearer_payload)
+    except (KeyError, IndexError, ValueError) as exc:
+        print(f"No flamebearer data for flame graph: {title} ({exc})")
+        return
+    if not levels or total_ticks <= 0:
+        print(f"No flamebearer data for flame graph: {title}")
+        return
+
+    highlight = highlight or {}
+    min_label_ticks = total_ticks * _MIN_LABEL_FRACTION
+    n_levels = len(levels)
+    fig_width = 14.0
+    plot_height_in = max(2.0, min(26.0, n_levels * _ROW_HEIGHT_IN))
+    fig_height = plot_height_in + _TOP_MARGIN_IN + _BOTTOM_MARGIN_IN
+    fig = plt.figure(figsize=(fig_width, fig_height))
+
+    # A fixed-fraction rect (not plt.subplots) so tight_layout -- called
+    # unconditionally by save_figure() -- leaves this axes alone; see the
+    # module docstring for why that matters here.
+    left = _SIDE_MARGIN_IN / fig_width
+    bottom = _BOTTOM_MARGIN_IN / fig_height
+    top = 1 - _TOP_MARGIN_IN / fig_height
+    ax = fig.add_axes((left, bottom, 1 - 2 * left, top - bottom))
+
+    for depth, row in enumerate(levels):
+        bars = [
+            (start, end - start)
+            for start, end, _total, _self, _name in row
+            if end > start
+        ]
+        colors = [
+            highlight.get(name, _OTHER_COLOR)
+            for _s, _e, _t, _sf, name in row
+            if _e > _s
+        ]
+        if not bars:
+            continue
+        ax.broken_barh(
+            bars, (depth, 0.9), facecolors=colors, edgecolors="white", linewidth=0.15
+        )
+        for start, end, _total, _self, name in row:
+            width = end - start
+            if width < min_label_ticks:
+                continue
+            label = ax.text(
+                start + width / 2,
+                depth + 0.45,
+                name,
+                ha="center",
+                va="center",
+                fontsize=6,
+                clip_on=True,
+            )
+            # Clip to this box's own rectangle so a label never bleeds into a
+            # neighboring frame -- axes-boundary clipping alone doesn't do this.
+            clip_box = plt.Rectangle((start, depth), width, 0.9, transform=ax.transData)
+            label.set_clip_path(clip_box)
+
+    ax.set_xlim(0, total_ticks)
+    ax.set_ylim(0, n_levels)
+    ax.invert_yaxis()
+    ax.set_xticks([])
+    ax.set_yticks([])
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    scope = f"'{focus}' total" if focus else "total"
+    ax.set_xlabel(f"CPU time ({scope} {total_ticks / rate:.2f}s)", fontsize=11)
+
+    # Title and legend live in the fixed top margin, positioned in absolute
+    # figure-fraction terms (derived from fig_height, which we control) so
+    # they never collide regardless of how short the cropped graph is -- an
+    # axes-fraction bbox_to_anchor (e.g. 1.06) shrinks to almost nothing in
+    # physical terms once the axes itself is only ~2in tall.
+    fig.text(0.5, 1 - 0.32 / fig_height, title, ha="center", va="top", fontsize=14)
+
+    legend_patches = [
+        mpatches.Patch(color=_CRYPTO_COLOR, label="crypto (verify)"),
+        mpatches.Patch(color=_DB_READ_COLOR, label="db read (mget)"),
+        mpatches.Patch(color=_DB_WRITE_COLOR, label="db write (run_script)"),
+        mpatches.Patch(color=_SERIALIZE_COLOR, label="serialize"),
+        mpatches.Patch(color=_OTHER_COLOR, label="other"),
+    ]
+    fig.legend(
+        handles=legend_patches,
+        loc="center",
+        bbox_to_anchor=(0.5, 1 - 0.72 / fig_height),
+        bbox_transform=fig.transFigure,
+        ncol=4,
+        fontsize=9,
+    )
+
+    with warnings.catch_warnings():
+        # Expected: save_figure()'s tight_layout() call skips this add_axes
+        # axes by design (see module docstring); the warning would otherwise
+        # fire on every single flame graph rendered.
+        warnings.filterwarnings("ignore", message="This figure includes Axes")
+        save_figure(fig, output_path)
+    print(f"Flame graph saved to: {output_path}")

--- a/bench-plotter/src/bench_plotter/plotting/histogram_math.py
+++ b/bench-plotter/src/bench_plotter/plotting/histogram_math.py
@@ -2,9 +2,86 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional, Tuple
 
 import numpy as np
+
+
+def _bucket_weights(
+    edges: List[float], cumulative: List[float]
+) -> Tuple[List[float], List[float]]:
+    """Difference a cumulative histogram into per-bucket (lower edge, weight).
+
+    The first bucket's lower edge is 0: these histograms measure durations and
+    byte counts, so nothing falls below zero.
+    """
+    lowers: List[float] = []
+    weights: List[float] = []
+    prev_edge = 0.0
+    prev_cum = 0.0
+    for edge, cum in zip(edges, cumulative):
+        weights.append(max(0.0, float(cum) - prev_cum))
+        lowers.append(prev_edge)
+        prev_edge = float(edge)
+        prev_cum = float(cum)
+    return lowers, weights
+
+
+def histogram_moments(
+    edges: List[float], cumulative: List[float]
+) -> Tuple[Optional[float], Optional[float]]:
+    """Return ``(mean, population stddev)`` of a cumulative histogram.
+
+    Each bucket contributes its midpoint, weighted by its share of the total, so
+    both moments are bucket-resolution estimates rather than measured values: the
+    spread *within* a bucket is invisible, which biases the stddev low. Callers
+    exclude Prometheus' ``+Inf`` bucket (it has no upper bound to take a midpoint
+    of), so observations past the largest finite edge are not represented either.
+
+    Returns ``(None, None)`` when the inputs are misaligned or carry no weight.
+    """
+    if not edges or len(edges) != len(cumulative):
+        return None, None
+    lowers, weights = _bucket_weights(edges, cumulative)
+    total = sum(weights)
+    if total <= 0:
+        return None, None
+    midpoints = np.array(
+        [(lower + float(upper)) / 2.0 for lower, upper in zip(lowers, edges)]
+    )
+    shares = np.array(weights) / total
+    mean = float(np.sum(shares * midpoints))
+    variance = float(np.sum(shares * (midpoints - mean) ** 2))
+    return mean, float(np.sqrt(max(0.0, variance)))
+
+
+def histogram_quantile(
+    edges: List[float], cumulative: List[float], quantile: float
+) -> Optional[float]:
+    """Interpolate a quantile from a cumulative histogram.
+
+    Locates the bucket the quantile falls in and interpolates linearly across it,
+    the same approximation Prometheus' ``histogram_quantile`` makes. ``cumulative``
+    is normalized by its last (largest) entry, so it may be either counts or
+    fractions, and need not reach 1 when the ``+Inf`` bucket was excluded.
+    """
+    if not edges or len(edges) != len(cumulative):
+        return None
+    total = float(cumulative[-1])
+    if total <= 0:
+        return None
+    target = quantile * total
+    prev_edge = 0.0
+    prev_cum = 0.0
+    for edge, cum in zip(edges, cumulative):
+        current = float(cum)
+        if current >= target:
+            if current <= prev_cum:
+                return float(edge)
+            fraction = (target - prev_cum) / (current - prev_cum)
+            return prev_edge + fraction * (float(edge) - prev_edge)
+        prev_edge, prev_cum = float(edge), current
+    return float(edges[-1])
 
 
 def histogram_to_samples(
@@ -25,15 +102,7 @@ def histogram_to_samples(
     """
     if not edges or len(edges) != len(cumulative):
         return []
-    lowers: List[float] = []
-    weights: List[float] = []
-    prev_edge = 0.0
-    prev_cum = 0.0
-    for edge, cum in zip(edges, cumulative):
-        weights.append(max(0.0, float(cum) - prev_cum))
-        lowers.append(prev_edge)
-        prev_edge = float(edge)
-        prev_cum = float(cum)
+    lowers, weights = _bucket_weights(edges, cumulative)
     total = sum(weights)
     if total <= 0:
         return []

--- a/bench-plotter/src/bench_plotter/plotting/profile_bar_renderer.py
+++ b/bench-plotter/src/bench_plotter/plotting/profile_bar_renderer.py
@@ -1,0 +1,254 @@
+"""Per-mode vendor CPU time comparison: one stacked-bar PNG per TPS, plus a
+combined CSV + rendered table image across every (tps, mode) cell.
+
+x-axis = mode, sorted descending by total CPU time per payment so the
+costliest mode reads first. Stacked bar segments = crypto / db read / db
+write / serialize / other (unaccounted) CPU time per payment within that
+mode's endpoint handler, in microseconds. The CSV keeps the underlying
+absolute seconds and per-payment milliseconds.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+import matplotlib.pyplot as plt
+
+from .common import save_figure
+from .table_renderer import format_cell, render_table_figure, write_table_csv
+
+_CRYPTO_COLOR = "#eda100"
+# Two shades of the same blue: the split into read/write is a subdivision of
+# what used to be one db segment, and the shared hue keeps that readable.
+_DB_READ_COLOR = "#7db8ef"
+_DB_WRITE_COLOR = "#1f5fae"
+_SERIALIZE_COLOR = "#7b4ea3"
+_OTHER_COLOR = "#b0b0b0"
+
+# Label colour per segment fill: on top of the fill, chosen for contrast against
+# it; beside the bar, a darkened version of the fill so a label sitting outside
+# still says which segment it belongs to.
+_INSIDE_TEXT_COLOR = {
+    _CRYPTO_COLOR: "black",
+    _DB_READ_COLOR: "black",
+    _DB_WRITE_COLOR: "white",
+    _SERIALIZE_COLOR: "white",
+    _OTHER_COLOR: "black",
+}
+_OUTSIDE_TEXT_COLOR = {
+    _CRYPTO_COLOR: "#8a5e00",
+    _DB_READ_COLOR: "#2a78d6",
+    _DB_WRITE_COLOR: _DB_WRITE_COLOR,
+    _SERIALIZE_COLOR: _SERIALIZE_COLOR,
+    _OTHER_COLOR: "#5f5f5f",
+}
+
+# A segment thinner than this fraction of the tallest bar cannot hold its digits
+# without them spilling into its neighbours, so its label goes beside the bar
+# instead. The crypto segment is routinely this thin for the cheaper modes, and
+# it is the one the chart exists to compare, so dropping the label is not an
+# option.
+_MIN_INSIDE_LABEL_FRACTION = 0.045
+
+# Bar geometry, in x-axis units (one unit per mode). Narrower than matplotlib's
+# 0.8 default to leave room for the labels of thin segments beside each bar.
+_BAR_WIDTH = 0.62
+_LABEL_GAP = 0.04
+
+# Records carry per-payment CPU time in milliseconds, but a payment costs tens
+# to hundreds of microseconds, so the chart plots microseconds: the segment
+# labels then read 20.8 and 268 instead of 0.0208 and 0.268.
+_MS_TO_US = 1000.0
+
+# Stack order (bottom to top): legend label, record field, fill colour.
+_BAR_SEGMENTS = (
+    ("crypto (verify)", "crypto_ms_per_payment", _CRYPTO_COLOR),
+    ("db read (mget)", "db_read_ms_per_payment", _DB_READ_COLOR),
+    ("db write (run_script)", "db_write_ms_per_payment", _DB_WRITE_COLOR),
+    ("serialize", "serialize_ms_per_payment", _SERIALIZE_COLOR),
+    ("other", "other_ms_per_payment", _OTHER_COLOR),
+)
+
+_CSV_FIELDS = [
+    "tps",
+    "mode",
+    "total_time_s",
+    "run_endpoint_time_s",
+    "macro_time_s",
+    "crypto_time_s",
+    "db_read_time_s",
+    "db_write_time_s",
+    "serialize_time_s",
+    "other_time_s",
+    "profile_payments",
+    "crypto_ms_per_payment",
+    "db_read_ms_per_payment",
+    "db_write_ms_per_payment",
+    "serialize_ms_per_payment",
+    "other_ms_per_payment",
+]
+
+
+def _label_segments(
+    ax: Any,
+    x: Sequence[int],
+    bottoms: Sequence[float],
+    values: Sequence[float],
+    color: str,
+    threshold: float,
+) -> None:
+    """Label every segment at its vertical centre, inside it or beside the bar."""
+    for xi, bottom, value in zip(x, bottoms, values):
+        if value <= 0:
+            continue
+        centre = bottom + value / 2
+        if value >= threshold:
+            ax.text(
+                xi,
+                centre,
+                format_cell(value),
+                ha="center",
+                va="center",
+                fontsize=9,
+                fontweight="bold",
+                color=_INSIDE_TEXT_COLOR[color],
+            )
+            continue
+        ax.text(
+            xi + _BAR_WIDTH / 2 + _LABEL_GAP,
+            centre,
+            format_cell(value),
+            ha="left",
+            va="center",
+            fontsize=9,
+            fontweight="bold",
+            color=_OUTSIDE_TEXT_COLOR[color],
+        )
+
+
+def create_macro_micro_bar(
+    records: List[Dict[str, Any]],
+    title: str = "Vendor CPU time per payment: macro vs micro by mode",
+    output_path: str = "profile_macro_micro.png",
+) -> None:
+    """Stacked bar per mode (crypto/db read/db write/serialize/other) for one
+    TPS level.
+
+    Bars are CPU microseconds **per payment** rather than the run's absolute
+    seconds. A mode's absolute total scales with however many payments its
+    window covered, so bar heights are only comparable across modes when every
+    mode served the same count -- normalizing removes that dependency and is
+    the like-for-like question anyway ("what does one payment cost").
+
+    Each entry in ``records`` must provide ``mode`` and the
+    ``*_ms_per_payment`` fields; records whose payment count was unavailable
+    (leaving those fields ``None``) are dropped, since there is nothing to
+    normalize by. Callers pass one TPS's worth of records per call (one PNG per
+    TPS) rather than faceting multiple TPS into a single image, so each chart
+    is legible on its own.
+
+    Every segment is labelled with its own value and every bar with its total,
+    so the chart is readable without opening the companion table.
+    """
+    usable = [
+        r
+        for r in records
+        if all(r.get(field) is not None for _, field, _ in _BAR_SEGMENTS)
+    ]
+    if not usable:
+        print(f"No profile records with a payment count for chart: {title}")
+        return
+
+    rows = {r["mode"]: r for r in usable}
+    totals_by_mode = {
+        m: sum(float(r[field]) for _, field, _ in _BAR_SEGMENTS) for m, r in rows.items()
+    }
+    # Descending by total CPU time per payment, so the costliest mode -- the one
+    # this chart exists to flag -- reads first, left to right.
+    modes = sorted(rows.keys(), key=lambda m: totals_by_mode[m], reverse=True)
+    x = list(range(len(modes)))
+    values = [
+        [float(rows[m][field]) * _MS_TO_US for m in modes]
+        for _, field, _ in _BAR_SEGMENTS
+    ]
+    bottoms: List[List[float]] = []
+    running = [0.0] * len(modes)
+    for segment_values in values:
+        bottoms.append(list(running))
+        running = [b + v for b, v in zip(running, segment_values)]
+    totals = running
+
+    fig, ax = plt.subplots(figsize=(max(7, 1.8 * len(modes)), 6.5))
+    for (label, _, color), segment_values, bottom in zip(
+        _BAR_SEGMENTS, values, bottoms
+    ):
+        ax.bar(
+            x,
+            segment_values,
+            width=_BAR_WIDTH,
+            bottom=bottom,
+            color=color,
+            label=label,
+        )
+
+    tallest = max(totals) if totals else 0.0
+    threshold = tallest * _MIN_INSIDE_LABEL_FRACTION
+    for (_, _, color), segment_values, bottom in zip(_BAR_SEGMENTS, values, bottoms):
+        _label_segments(ax, x, bottom, segment_values, color, threshold)
+    for xi, total in zip(x, totals):
+        ax.text(
+            xi,
+            total + tallest * 0.015,
+            format_cell(total),
+            ha="center",
+            va="bottom",
+            fontsize=10,
+            fontweight="bold",
+        )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(modes, rotation=30, ha="right")
+    ax.set_ylabel("CPU time per payment (µs)", fontsize=14)
+    # Margin wide enough for a beside-the-bar label on the last mode too.
+    ax.set_xlim(-0.5 - _BAR_WIDTH / 2, len(modes) - 0.5 + _BAR_WIDTH)
+    ax.grid(True, axis="y", alpha=0.3)
+    ax.tick_params(axis="both", which="major", labelsize=11)
+    # Headroom for the per-bar totals, which sit just above the tallest bar.
+    if tallest > 0:
+        ax.set_ylim(bottom=0, top=tallest * 1.1)
+    # The legend goes above the axes, between them and the title: inside the
+    # axes it covers the tallest bar, which is the one the chart is about.
+    ax.legend(
+        loc="lower center",
+        bbox_to_anchor=(0.5, 1.0),
+        ncol=len(_BAR_SEGMENTS),
+        frameon=False,
+        fontsize=10,
+    )
+    ax.set_title(title, fontsize=15, pad=32)
+
+    save_figure(fig, output_path)
+    print(f"Macro/micro bar chart saved to: {output_path}")
+
+
+def create_macro_micro_table(
+    records: List[Dict[str, Any]],
+    title: str = "Vendor CPU time by mode and TPS",
+    output_path: str = "profile_macro_micro_table.png",
+) -> None:
+    """Write the combined (tps, mode) data as both a CSV and a rendered table PNG."""
+    if not records:
+        print(f"No profile records for macro/micro table: {title}")
+        return
+
+    sorted_rows = sorted(records, key=lambda r: (r["tps"], r["mode"]))
+    raw_rows = [[row.get(field) for field in _CSV_FIELDS] for row in sorted_rows]
+    csv_path = write_table_csv(_CSV_FIELDS, raw_rows, output_path)
+
+    cell_text = [
+        [str(int(row["tps"])), row["mode"]]
+        + [format_cell(row.get(field)) for field in _CSV_FIELDS[2:]]
+        for row in sorted_rows
+    ]
+    render_table_figure(_CSV_FIELDS, cell_text, title, output_path)
+    print(f"Macro/micro table saved to: {output_path} (data: {csv_path})")

--- a/bench-plotter/src/bench_plotter/plotting/sweep_renderers.py
+++ b/bench-plotter/src/bench_plotter/plotting/sweep_renderers.py
@@ -1,4 +1,4 @@
-"""Matplotlib figure builders for TPS-sweep charts (metric vs TPS)."""
+"""Matplotlib figure builders for TPS-sweep charts and tables (metric vs TPS)."""
 
 from __future__ import annotations
 
@@ -6,8 +6,10 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.ticker import FuncFormatter
 
 from .common import PALETTE, save_figure
+from .table_renderer import render_table_figure, write_table_csv
 
 _LINESTYLES = ["-", "--", "-.", ":", (0, (3, 1, 1, 1))]
 _MARKERS = ["o", "s", "^", "D", "v", "P", "X", "*"]
@@ -141,3 +143,160 @@ def create_sweep_line_plot(
     ax.set_ylim(bottom=0, top=top_limit)
     save_figure(fig, output_path)
     print(f"Sweep line plot saved to: {output_path}")
+
+
+def create_identity_comparison_plot(
+    series_list: List[Dict[str, Any]],
+    title: str = "Achieved vs Target",
+    output_path: str = "identity_comparison.png",
+    x_axis_label: str = "Target",
+    y_axis_label: str = "Achieved",
+    identity_label: str = "y = x (ideal)",
+) -> None:
+    """Plot achieved-vs-target series against the ``y = x`` identity line.
+
+    Purpose-built for reading a saturation curve, so the geometry carries the
+    meaning: both axes get one shared base-2 log scale, identical limits, and
+    identical ticks, with equal aspect. The identity line therefore runs at a
+    true 45 degrees and vertical distance below it *is* the shortfall -- on
+    mismatched axes a client that fell 3x short can look like it tracked the
+    target. The log scale is what makes a doubling sweep legible: on a linear
+    axis every point below 256 crowds into the left margin.
+
+    Each entry in ``series_list`` is
+    ``{"x_values": [...], "y_values": [...], "label": str}`` with optional
+    ``color`` and ``marker``. The identity line is drawn by this function, so
+    callers pass only measured series.
+    """
+    if not series_list:
+        print("No series provided for identity comparison plot")
+        return
+
+    # Both scales are logarithmic, so non-positive points cannot be drawn at all.
+    # Drop them here (rather than letting matplotlib silently clip) and keep the
+    # surviving pairs per series.
+    cleaned: List[Dict[str, Any]] = []
+    all_values: List[float] = []
+    all_x: List[float] = []
+    for idx, series in enumerate(series_list):
+        pairs = [
+            (float(x), float(y))
+            for x, y in zip(series.get("x_values", []), series.get("y_values", []))
+            if x is not None and y is not None and float(x) > 0 and float(y) > 0
+        ]
+        if not pairs:
+            continue
+        pairs.sort(key=lambda p: p[0])
+        cleaned.append({**series, "_pairs": pairs, "_idx": idx})
+        all_x.extend(p[0] for p in pairs)
+        all_values.extend(p[0] for p in pairs)
+        all_values.extend(p[1] for p in pairs)
+
+    if not cleaned:
+        print("No drawable points for identity comparison plot")
+        return
+
+    # One padded range shared by both axes; multiplicative padding because the
+    # axes are logarithmic.
+    lo = min(all_values) / 1.4
+    hi = max(all_values) * 1.4
+
+    fig, ax = plt.subplots(figsize=(9, 9))
+
+    # Identity line first so the measured series draw on top of it.
+    ax.plot(
+        [lo, hi],
+        [lo, hi],
+        color="#6b7280",
+        linewidth=1.8,
+        linestyle="--",
+        zorder=1,
+        label=identity_label,
+    )
+
+    for series in cleaned:
+        pairs = series["_pairs"]
+        idx = series["_idx"]
+        ax.plot(
+            [p[0] for p in pairs],
+            [p[1] for p in pairs],
+            color=series.get("color") or PALETTE[idx % len(PALETTE)],
+            linewidth=2,
+            linestyle="-",
+            marker=series.get("marker") or _MARKERS[idx % len(_MARKERS)],
+            markersize=8,
+            zorder=2,
+            label=series.get("label") or f"Series {idx + 1}",
+        )
+
+    for axis_setter, tick_setter in (
+        (ax.set_xscale, ax.set_xticks),
+        (ax.set_yscale, ax.set_yticks),
+    ):
+        axis_setter("log", base=2)
+        # Tick at the swept targets on *both* axes: shared gridlines are what let
+        # a reader check a point against the identity line by eye.
+        tick_setter(sorted(set(all_x)))
+    ax.set_xlim(lo, hi)
+    ax.set_ylim(lo, hi)
+    # Equal aspect on matched log scales renders y = x at a true 45 degrees.
+    ax.set_aspect("equal")
+    ax.minorticks_off()
+    ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _pos: f"{v:g}"))
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _pos: f"{v:g}"))
+
+    ax.set_xlabel(x_axis_label, fontsize=14)
+    ax.set_ylabel(y_axis_label, fontsize=14)
+    ax.set_title(title, fontsize=16)
+    ax.grid(True, alpha=0.3, which="major")
+    ax.legend(fontsize=12, loc="upper left")
+    ax.tick_params(axis="both", which="major", labelsize=12)
+    save_figure(fig, output_path)
+    print(f"Identity comparison plot saved to: {output_path}")
+
+
+_MISSING_CELL = "-"
+
+
+def _format_cell(tps: float, achieved: Optional[float]) -> str:
+    """Real TPS with the percentage of target achieved in parentheses, or a placeholder.
+
+    100% means the run hit its target exactly; below 100% is a shortfall and
+    above 100% is an overshoot (typically sampling noise around an on-target run).
+    """
+    if achieved is None:
+        return _MISSING_CELL
+    pct = achieved / tps * 100 if tps else 0.0
+    return f"{achieved:.1f} ({pct:.1f}%)"
+
+
+def create_delta_table(
+    tps_values: Sequence[float],
+    modes: Sequence[str],
+    achieved: Sequence[Sequence[Optional[float]]],
+    title: str = "Real TPS by target and protocol (% = of target achieved)",
+    output_path: str = "delta_table.png",
+    row_header: str = "Target TPS",
+) -> None:
+    """Render a target-TPS x protocol grid of real TPS as a CSV and a table PNG.
+
+    ``achieved[row][col]`` pairs with ``tps_values[row]`` and ``modes[col]``; a
+    ``None`` cell renders as a placeholder rather than a misleading 0. Written
+    alongside the chart because the chart shows *where* a protocol stops keeping
+    up while this gives the magnitude at each step.
+    """
+    if not tps_values or not modes:
+        print("No data for delta table")
+        return
+
+    col_labels = [row_header] + list(modes)
+    cell_text = [
+        [f"{tps:g}"] + [_format_cell(tps, a) for a in row]
+        for tps, row in zip(tps_values, achieved)
+    ]
+
+    csv_path = write_table_csv(col_labels, cell_text, output_path)
+    render_table_figure(
+        col_labels, cell_text, title, output_path, bold_first_column=True
+    )
+    print(f"Delta table saved to: {output_path} (data: {csv_path})")

--- a/bench-plotter/src/bench_plotter/plotting/table_renderer.py
+++ b/bench-plotter/src/bench_plotter/plotting/table_renderer.py
@@ -1,0 +1,108 @@
+"""Tabular output: a rendered table PNG plus a sibling CSV of the same data.
+
+Every "chart + the numbers behind it" pair in the package goes through here, so
+the matplotlib table styling (stretched bbox, coloured header row, autosized
+columns) and the ``<name>.png`` -> ``<name>.csv`` convention are defined once.
+
+Callers pass *raw* row values: the CSV keeps them verbatim (so it stays
+machine-readable at full precision) while the PNG shows them formatted for
+reading.
+"""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, List, Sequence
+
+import matplotlib.pyplot as plt
+
+from .common import save_figure
+
+_HEADER_COLOR = "#2a78d6"
+_MISSING_CELL = "-"
+
+
+def write_table_csv(
+    col_labels: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+    output_path: str,
+) -> str:
+    """Write ``rows`` as a CSV beside ``output_path``; return the CSV path."""
+    csv_path = str(Path(output_path).with_suffix(".csv"))
+    Path(csv_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(list(col_labels))
+        writer.writerows([list(row) for row in rows])
+    return csv_path
+
+
+def render_table_figure(
+    col_labels: Sequence[str],
+    cell_text: Sequence[Sequence[str]],
+    title: str,
+    output_path: str,
+    *,
+    bold_first_column: bool = False,
+) -> None:
+    """Render already-formatted cell strings as a table PNG."""
+    fig_height = 0.4 * (len(cell_text) + 1) + 0.9
+    fig, ax = plt.subplots(figsize=(max(8, 1.9 * len(col_labels)), fig_height))
+    ax.axis("off")
+    # bbox stretches the table to fill the axes; the default loc="center" keeps it
+    # at its intrinsic (small) size and leaves the rest of the figure blank.
+    table = ax.table(
+        cellText=[list(row) for row in cell_text],
+        colLabels=list(col_labels),
+        bbox=(0, 0, 1, 1),  # type: ignore[arg-type]  # matplotlib accepts a 4-tuple; stub only types Bbox
+        cellLoc="center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(10)
+    table.auto_set_column_width(list(range(len(col_labels))))
+    for (row, col), cell in table.get_celld().items():
+        if row == 0:
+            cell.set_text_props(weight="bold", color="white")
+            cell.set_facecolor(_HEADER_COLOR)
+        elif col == 0 and bold_first_column:
+            cell.set_text_props(weight="bold")
+    ax.set_title(title, fontsize=14, pad=14)
+
+    save_figure(fig, output_path)
+
+
+def format_cell(value: Any) -> str:
+    """Format one raw value for display: 3 significant figures, ``-`` for missing.
+
+    Magnitudes of 1000 and up print in full rather than in the scientific notation
+    ``%g`` switches to, because these are CPU seconds and payment counts that a
+    reader compares digit-for-digit against the neighbouring cells and against the
+    run's configured request count -- ``1.74e+03`` beside ``938`` defeats that.
+    """
+    if value is None:
+        return _MISSING_CELL
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return str(value)
+    numeric = float(value)
+    if abs(numeric) >= 1000:
+        return f"{numeric:.0f}"
+    return f"{numeric:.3g}"
+
+
+def create_stats_table(
+    col_labels: Sequence[str],
+    rows: Sequence[Sequence[Any]],
+    title: str = "Statistics",
+    output_path: str = "table.png",
+) -> None:
+    """Write ``rows`` as both a CSV (raw values) and a table PNG (formatted)."""
+    if not rows:
+        print(f"No rows for table: {title}")
+        return
+    csv_path = write_table_csv(col_labels, rows, output_path)
+    cell_text: List[List[str]] = [[format_cell(v) for v in row] for row in rows]
+    render_table_figure(
+        col_labels, cell_text, title, output_path, bold_first_column=True
+    )
+    print(f"Table saved to: {output_path} (data: {csv_path})")

--- a/bench-plotter/src/bench_plotter/plotting/timeseries_renderers.py
+++ b/bench-plotter/src/bench_plotter/plotting/timeseries_renderers.py
@@ -6,7 +6,17 @@ from typing import Any, List, Dict
 
 import matplotlib.pyplot as plt
 
-from .common import save_figure
+from bench_plotter.mode_style import MODE_MARKERS
+
+from .common import PALETTE, save_figure
+
+# One marker per point, at a sparse stride: a marker on every raw Prometheus
+# sample would be an unreadable smear, but the shape still needs to appear
+# often enough to tell series apart without relying on color alone (this
+# benchmark's convention -- see mode_style.MODE_MARKERS). Color + marker is
+# the full identity encoding here -- there is only one dimension (series),
+# so linestyle stays fixed rather than cycling too and double-encoding it.
+_MARKER_EVERY = 15
 
 
 def create_multi_line_plot(
@@ -20,8 +30,6 @@ def create_multi_line_plot(
         print("No series provided for multi-series plotting")
         return
     fig, ax = plt.subplots(figsize=(12, 8))
-    colors = ["tab:blue", "tab:orange", "tab:green", "tab:red", "tab:purple"]
-    linestyles = ["-", "--", "-.", ":", (0, (3, 1, 1, 1))]
     max_value = 0.0
     for idx, series in enumerate(series_list):
         timestamps = series.get("timestamps", [])
@@ -38,8 +46,8 @@ def create_multi_line_plot(
             continue
 
         start_time = float(timestamps[0])
-        color = colors[idx % len(colors)]
-        linestyle = linestyles[idx % len(linestyles)]
+        color = PALETTE[idx % len(PALETTE)]
+        marker = MODE_MARKERS[idx % len(MODE_MARKERS)]
 
         plot_elapsed = [float(ts) - start_time for ts in timestamps]
         plot_values = values
@@ -49,7 +57,9 @@ def create_multi_line_plot(
             plot_values,
             color=color,
             linewidth=2,
-            linestyle=linestyle,
+            marker=marker,
+            markevery=_MARKER_EVERY,
+            markersize=7,
             label=label,
         )
         max_value = max(max_value, max(valid_values))

--- a/bench-plotter/src/bench_plotter/profiling/__init__.py
+++ b/bench-plotter/src/bench_plotter/profiling/__init__.py
@@ -1,0 +1,1 @@
+"""Per-mode CPU profiling: Pyroscope-backed flame graphs and macro/micro time extraction."""

--- a/bench-plotter/src/bench_plotter/profiling/aggregate.py
+++ b/bench-plotter/src/bench_plotter/profiling/aggregate.py
@@ -1,0 +1,436 @@
+"""Per-run CPU profiling via Pyroscope: flame graphs + macro/micro time extraction.
+
+Mirrors ``sweep/aggregate.py``'s shape (per-run window fetch, bounded
+concurrency, DrawTask emission) but against Pyroscope instead of Prometheus,
+and reduces a merged call tree instead of a value time series.
+
+Pyroscope's ``/render`` returns one aggregated tree over the requested
+``[from, until]`` window, not a value series, so the warm-up/cool-down
+trimming that ``steady_state_samples`` does for Prometheus series (drop
+samples outside +/-20% of the median) doesn't apply here -- and it isn't
+needed. The run window is queried whole, because the harness already isolates
+it: ``run_benchmark.sh`` sleeps before launching the client and drains after
+it exits, so ``[start_ms, finish_ms]`` has idle margins at both ends.
+Verified against a live run: padding the window outward by up to 15s changes
+neither the payment count nor any CPU bucket, for every mode.
+
+Trimming a fraction off each end (a previous approach) actively hurt. CPU
+comes back in 15s buckets (``timeline.durationDelta`` in the response) and
+whole overlapping buckets are returned, while the Prometheus payment counter
+follows the requested window much more finely. Sliding the window therefore
+moved numerator and denominator on different grids, adding ~10% of scatter to
+every per-payment number, and cutting into the front of the window truncated
+the counter delta -- the payment count is only complete when the window
+starts in an idle margin, before the first payment.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from bench_plotter import pyroscope_fetch
+from bench_plotter.flamebearer import (
+    build_tree,
+    outermost_nodes,
+    root_total_ticks,
+    sample_rate,
+    sum_ticks_by_name,
+    sum_ticks_within,
+)
+from bench_plotter.metric_queries import PAYMENT_COUNTER_METRIC_BY_MODE
+from bench_plotter.mode_style import series_by_mode
+from bench_plotter.pipeline.draw import draw_all
+from bench_plotter.pipeline.model import DrawTask
+from bench_plotter.plotting.profile_bar_renderer import (
+    _CRYPTO_COLOR,
+    _DB_READ_COLOR,
+    _DB_WRITE_COLOR,
+    _SERIALIZE_COLOR,
+)
+from bench_plotter.profiling.mode_functions import (
+    MODE_FUNCTIONS,
+    RUN_ENDPOINT_FUNCTION,
+    VENDOR_PROFILE_QUERY,
+)
+from bench_plotter.prometheus_fetch import query_range
+from bench_plotter.prometheus_matrix import matrix_to_per_series_charts
+
+_MAX_CONCURRENCY = 4
+
+# Absolute CPU-time field -> its per-payment counterpart (milliseconds).
+_PER_PAYMENT_FIELDS = {
+    "crypto_time_s": "crypto_ms_per_payment",
+    "db_read_time_s": "db_read_ms_per_payment",
+    "db_write_time_s": "db_write_ms_per_payment",
+    "serialize_time_s": "serialize_ms_per_payment",
+    "other_time_s": "other_ms_per_payment",
+}
+
+
+def _extract_record(payload: Dict[str, Any], mode: str, tps: float) -> Dict[str, Any]:
+    root = build_tree(payload)
+    rate = sample_rate(payload)
+    if rate <= 0:
+        raise ValueError("flamebearer sampleRate is not positive")
+
+    def seconds(ticks: int) -> float:
+        return ticks / rate
+
+    cfg = MODE_FUNCTIONS[mode]
+    run_endpoint_ticks = sum(sum_ticks_by_name(root, [RUN_ENDPOINT_FUNCTION]).values())
+
+    endpoint_nodes = outermost_nodes(root, cfg["endpoint"])
+    macro_ticks = sum(n.total_ticks for n in endpoint_nodes)
+
+    # The db buckets are measured at the store primitives (reads and writes go
+    # through different ones) and serialization happens in the repositories
+    # around those calls, so the four micro buckets are disjoint subtrees of the
+    # endpoint and need no netting out of one another. other is the residual of
+    # macro: framework, request/response handling, repository bookkeeping and
+    # the issuer round trip.
+    micro_ticks = sum_ticks_within(
+        endpoint_nodes,
+        cfg["crypto"] + cfg["db_read"] + cfg["db_write"] + cfg["serialize"],
+    )
+
+    def bucket_ticks(names: List[str]) -> int:
+        return sum(micro_ticks.get(name, 0) for name in names)
+
+    crypto_ticks = bucket_ticks(cfg["crypto"])
+    db_read_ticks = bucket_ticks(cfg["db_read"])
+    db_write_ticks = bucket_ticks(cfg["db_write"])
+    serialize_ticks = bucket_ticks(cfg["serialize"])
+    other_ticks = max(
+        0,
+        macro_ticks - crypto_ticks - db_read_ticks - db_write_ticks - serialize_ticks,
+    )
+
+    return {
+        "mode": mode,
+        "tps": tps,
+        "total_time_s": seconds(root_total_ticks(payload)),
+        "run_endpoint_time_s": seconds(run_endpoint_ticks),
+        "macro_time_s": seconds(macro_ticks),
+        "crypto_time_s": seconds(crypto_ticks),
+        "db_read_time_s": seconds(db_read_ticks),
+        "db_write_time_s": seconds(db_write_ticks),
+        "serialize_time_s": seconds(serialize_ticks),
+        "other_time_s": seconds(other_ticks),
+        "payload": payload,
+    }
+
+
+def _counter_delta(payload: Dict[str, Any]) -> Optional[float]:
+    """Sum of each series' last-minus-first raw value.
+
+    ``None`` if no series had at least two samples in the window (nothing to
+    take a delta of), so the caller can tell "no data" apart from "zero
+    payments".
+    """
+    charts = matrix_to_per_series_charts(payload.get("data", {}).get("result", []))
+    total = 0.0
+    found = False
+    for chart in charts:
+        data = [v for v in (chart.get("data") or []) if v is not None]
+        if len(data) < 2:
+            continue
+        found = True
+        total += data[-1] - data[0]
+    return total if found else None
+
+
+async def _payments_served(
+    mode: str,
+    start: float,
+    end: float,
+) -> Optional[float]:
+    """Payments the vendor's own success counter recorded inside the profiled
+    window.
+
+    This used to be modeled from the target TPS and ``total_requests``,
+    assuming traffic ran at the target rate starting at the run's nominal
+    start. That assumption breaks for e.g. signature mode, whose client
+    blocks on a bulk client-side pre-signing phase (``client_pay_chan.py``)
+    before sending a single request -- sometimes for minutes -- so the model
+    counted payments the profiled window couldn't possibly have seen yet,
+    understating every per-payment CPU number derived from it. Reading the
+    counter directly (the same source ``saturation/aggregate.py`` uses for
+    achieved TPS) sidesteps modeling traffic altogether: whatever the vendor
+    actually served in ``[start, end]`` is what the profiled CPU time was
+    spent on, however traffic was paced or delayed.
+
+    Raises whatever ``query_range`` raises (unreachable/erroring Prometheus)
+    rather than degrading to a guess -- a per-payment number computed from a
+    wrong payment count is worse than no number at all.
+    """
+    metric = PAYMENT_COUNTER_METRIC_BY_MODE.get(mode)
+    if not metric:
+        return None
+    payload = await query_range(
+        query=f'{metric}{{job="vendor-api", status="success"}}',
+        start_unix=start,
+        end_unix=end,
+    )
+    return _counter_delta(payload)
+
+
+def _add_per_payment_fields(record: Dict[str, Any]) -> None:
+    """Fill the ``*_ms_per_payment`` fields from ``profile_payments``."""
+    payments = record.get("profile_payments")
+    for source, target in _PER_PAYMENT_FIELDS.items():
+        record[target] = (
+            record[source] / payments * 1000.0 if payments and payments > 0 else None
+        )
+
+
+async def _fetch_run_profile(
+    run: Dict[str, Any],
+    sem: asyncio.Semaphore,
+) -> Optional[Dict[str, Any]]:
+    mode = run.get("mode")
+    tps = run.get("tps")
+    if mode is None or tps is None or mode not in MODE_FUNCTIONS:
+        return None
+    ts = run.get("prometheus_timestamps", {}) or {}
+    start_ms, finish_ms = ts.get("start_ms"), ts.get("finish_ms")
+    if not start_ms or not finish_ms:
+        return None
+
+    start, end = start_ms / 1000.0, finish_ms / 1000.0
+
+    async with sem:
+        try:
+            payload = await pyroscope_fetch.render(
+                query=VENDOR_PROFILE_QUERY,
+                start_unix=start,
+                end_unix=end,
+            )
+        except Exception as exc:  # noqa: BLE001 - recorded as a skipped run
+            print(f"  pyroscope query failed for mode={mode} tps={tps}: {exc}")
+            return None
+
+        # Not caught here: unlike a down Pyroscope (skip just this one run), a
+        # down/erroring Prometheus means the payment count -- and therefore
+        # every per-payment number this profiling stage produces -- can't be
+        # trusted, so the failure is left to propagate up to
+        # build_profile_draw_tasks, which aborts the whole profiling stage.
+        payments = await _payments_served(str(mode), start, end)
+
+    try:
+        record = _extract_record(payload, mode, float(tps))
+    except Exception as exc:  # noqa: BLE001 - recorded as a skipped run
+        print(f"  profile extraction failed for mode={mode} tps={tps}: {exc}")
+        return None
+
+    record["total_requests"] = run.get("total_requests")
+    record["profile_payments"] = payments
+    _add_per_payment_fields(record)
+    return record
+
+
+async def _collect_profiles(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    sem = asyncio.Semaphore(_MAX_CONCURRENCY)
+    results = await asyncio.gather(*(_fetch_run_profile(r, sem) for r in runs))
+    return [r for r in results if r is not None]
+
+
+def _highlight_for_mode(mode: str) -> Dict[str, str]:
+    cfg = MODE_FUNCTIONS[mode]
+    highlight = {name: _CRYPTO_COLOR for name in cfg["crypto"]}
+    highlight.update({name: _DB_READ_COLOR for name in cfg["db_read"]})
+    highlight.update({name: _DB_WRITE_COLOR for name in cfg["db_write"]})
+    highlight.update({name: _SERIALIZE_COLOR for name in cfg["serialize"]})
+    return highlight
+
+
+def build_profile_draw_tasks(
+    runs: List[Dict[str, Any]],
+    output_dir: str,
+) -> List[DrawTask]:
+    """Fetch per-run profiles and return DrawTasks for flame graphs + the
+    aggregate macro/micro comparison. Returns ``[]`` (not raises) on any
+    failure to fetch/parse -- a down Pyroscope must not break the rest of the
+    sweep's plots."""
+    if not runs:
+        return []
+    print(f"Profiling {len(runs)} run(s) via Pyroscope...")
+    try:
+        records = asyncio.run(_collect_profiles(runs))
+    except Exception as exc:  # noqa: BLE001 - profiling is best-effort
+        print(f"Profiling stage failed: {exc}")
+        return []
+    if not records:
+        print("No profile records available; skipping profiling charts")
+        return []
+
+    base = Path(output_dir)
+    tasks: List[DrawTask] = []
+    for record in records:
+        mode = record["mode"]
+        tps = int(record["tps"])
+        total = int(record.get("total_requests") or 0)
+        cfg = MODE_FUNCTIONS[mode]
+        flame_path = base / f"tps{tps}_req{total}" / "profile" / f"flame_{mode}.png"
+        tasks.append(
+            DrawTask(
+                fn_name="flame_graph",
+                output_path=str(flame_path),
+                kwargs={
+                    "flamebearer_payload": record["payload"],
+                    "title": f"{mode} vendor CPU flame graph (tps={tps})",
+                    "highlight": _highlight_for_mode(mode),
+                    # Focus on the mode's own receive_*_payment endpoint
+                    # rather than run_endpoint_function -- it skips straight
+                    # to app code instead of also including the FastAPI
+                    # dispatch/dependency-injection frames above it.
+                    "focus": cfg["endpoint"],
+                },
+            )
+        )
+
+    bar_records = [{k: v for k, v in r.items() if k != "payload"} for r in records]
+
+    # One bar chart per TPS (not faceted into a single image), written into that
+    # TPS's own profile folder alongside that config's flame graphs.
+    for tps in sorted({r["tps"] for r in bar_records}):
+        rows = [r for r in bar_records if r["tps"] == tps]
+        total = int(rows[0].get("total_requests") or 0)
+        tasks.append(
+            DrawTask(
+                fn_name="profile_macro_micro_bar",
+                output_path=str(
+                    base
+                    / f"tps{int(tps)}_req{total}"
+                    / "profile"
+                    / "profile_macro_micro.png"
+                ),
+                kwargs={
+                    "records": rows,
+                    "title": (
+                        f"Vendor CPU time per payment: macro (endpoint) vs micro "
+                        f"(crypto/db read/db write/serialize) by mode "
+                        f"(tps={int(tps)})"
+                    ),
+                },
+            )
+        )
+
+    # The combined (tps, mode) table, as both a CSV and a rendered PNG.
+    tasks.append(
+        DrawTask(
+            fn_name="profile_macro_micro_table",
+            output_path=str(base / "profile_macro_micro_table.png"),
+            kwargs={
+                "records": bar_records,
+                "title": "Vendor CPU time by mode and TPS",
+            },
+        )
+    )
+
+    # The "general view": how each time category evolves across the sweep, one
+    # line per mode, mirroring the other vs-TPS aggregate charts. Each category
+    # gets two charts -- the CPU time the profiled window measured, and that time
+    # divided by the payments it was spent on. The absolute chart rises with TPS
+    # simply because there is more traffic in the window; only the per-payment
+    # one shows whether a payment got cheaper or more expensive.
+    for key, filename, label, y_label in (
+        (
+            "crypto_time_s",
+            "crypto_time_vs_tps.png",
+            "Crypto (verify) time",
+            "CPU time (s)",
+        ),
+        (
+            "db_read_time_s",
+            "db_read_time_vs_tps.png",
+            "DB read (mget) time",
+            "CPU time (s)",
+        ),
+        (
+            "db_write_time_s",
+            "db_write_time_vs_tps.png",
+            "DB write (run_script) time",
+            "CPU time (s)",
+        ),
+        (
+            "serialize_time_s",
+            "serialize_time_vs_tps.png",
+            "Serialize (dump/validate/json) time",
+            "CPU time (s)",
+        ),
+        (
+            "other_time_s",
+            "other_time_vs_tps.png",
+            "Other (unaccounted) time",
+            "CPU time (s)",
+        ),
+        (
+            "crypto_ms_per_payment",
+            "crypto_time_per_payment_vs_tps.png",
+            "Crypto (verify) time per payment",
+            "CPU time per payment (ms)",
+        ),
+        (
+            "db_read_ms_per_payment",
+            "db_read_time_per_payment_vs_tps.png",
+            "DB read (mget) time per payment",
+            "CPU time per payment (ms)",
+        ),
+        (
+            "db_write_ms_per_payment",
+            "db_write_time_per_payment_vs_tps.png",
+            "DB write (run_script) time per payment",
+            "CPU time per payment (ms)",
+        ),
+        (
+            "serialize_ms_per_payment",
+            "serialize_time_per_payment_vs_tps.png",
+            "Serialize (dump/validate/json) time per payment",
+            "CPU time per payment (ms)",
+        ),
+        (
+            "other_ms_per_payment",
+            "other_time_per_payment_vs_tps.png",
+            "Other (unaccounted) time per payment",
+            "CPU time per payment (ms)",
+        ),
+    ):
+        series = series_by_mode(bar_records, key)
+        if not series:
+            continue
+        tasks.append(
+            DrawTask(
+                fn_name="sweep_line",
+                output_path=str(base / filename),
+                kwargs={
+                    "series_list": series,
+                    "title": f"{label} vs TPS",
+                    "x_axis_label": "TPS",
+                    "y_axis_label": y_label,
+                },
+            )
+        )
+
+    return tasks
+
+
+def generate_profile_outputs(
+    runs: List[Dict[str, Any]],
+    output_dir: str,
+    workers: int | None = None,
+    parallel: bool = True,
+) -> List[str]:
+    """Build and render per-run flame graphs + the aggregate comparison chart."""
+    try:
+        tasks = build_profile_draw_tasks(runs, output_dir)
+    except Exception as exc:  # noqa: BLE001 - profiling is best-effort
+        print(f"Profiling stage failed to build tasks: {exc}")
+        return []
+    if not tasks:
+        return []
+    written, failures = draw_all(tasks, workers=workers, parallel=parallel)
+    for f in failures:
+        print(f"Profile draw failed for {f['output_path']}: {f['error']}")
+    return written

--- a/bench-plotter/src/bench_plotter/profiling/mode_functions.py
+++ b/bench-plotter/src/bench_plotter/profiling/mode_functions.py
@@ -1,0 +1,123 @@
+"""Per-mode CPU-time taxonomy: which flamebearer function names constitute the
+"endpoint" (macro, whole-request) span vs. the "crypto"/"db read"/"db
+write"/"serialize" (micro) spans for each payment mode.
+
+Datastore time is measured at the ``KeyValueStore`` primitives rather than at
+the repository entry points, so it contains only the datastore work itself
+(connection checkout, redis-py command encoding, socket I/O, reply parsing).
+That makes the buckets identical across modes by construction and removes any
+need to subtract nested marshalling from them: ``infrastructure/storage.py``
+imports no ``json``, so no ``serialize`` name can ever be a descendant of a
+primitive, and the buckets are disjoint. The repository's own Python (key
+f-strings, result dicts, reference parsing) lands in ``other``.
+
+The read/write split falls out of the primitives themselves, with no name
+overlap to resolve: every payment-path read is an ``mget`` (channel + state,
+or the merkle nodes), and every payment-path write is a Lua script run through
+``run_script`` (``save_payment``, ``merkle_merge_nodes``,
+``save_channel_and_initial_state``), because writes must be atomic against a
+concurrent payment on the same channel. Reads and writes cost differently --
+a write ships the serialized payload up and executes Lua server-side, a read
+ships keys up and parses the reply -- so charging them to one bucket hid which
+half of the datastore cost a scheme actually moves.
+
+``get`` is deliberately *not* a primitive here: the bare name collides with
+``httpx.AsyncClient.get``, which the issuer-fetch path calls inside the same
+endpoint span, and the two repository reads that use ``store.get`` (the
+duplicate/race branches) draw zero samples in a steady-state run.
+
+Function names are verified verbatim against a live Pyroscope trace of the
+vendor service (see profiling/aggregate.py docstring). ``verify`` is reused
+across the three paytree variants and payword: each mode's crypto scheme class
+defines its own ``verify`` method, but since extraction is scoped to one run's
+time window (one mode exercised per run), the bare name is unambiguous.
+``mget`` names both our store method and redis-py's; only the outermost
+occurrence is counted, so the inner frame is not double-counted.
+
+Serialize lists use leaf-level names only (no ancestor/descendant pairs in the
+same list) so ``sum_ticks_within`` does not double-count. Pydantic v2 marshals
+in its Rust core, so ``model_*`` frames never call Python ``json.dumps``/
+``json.loads``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, TypedDict
+
+
+class ModeFunctions(TypedDict):
+    endpoint: str
+    crypto: List[str]
+    db_read: List[str]
+    db_write: List[str]
+    serialize: List[str]
+
+
+# Every datastore round trip on every payment path goes through one of these
+# two KeyValueStore methods, so both db buckets are mode-independent.
+STORE_READS: List[str] = ["mget"]
+STORE_WRITES: List[str] = ["run_script"]
+
+
+# "paytree" is the paytree-std mode name, matching sweep/aggregate.py's
+# _KNOWN_MODES convention.
+MODE_FUNCTIONS: Dict[str, ModeFunctions] = {
+    "signature": {
+        "endpoint": "receive_payment",
+        "crypto": ["verify_signature_bytes"],
+        "db_read": STORE_READS,
+        "db_write": STORE_WRITES,
+        "serialize": [
+            "model_dump_json",
+            "model_validate_json",
+            "model_validate",
+            "loads",
+        ],
+    },
+    "paytree": {
+        "endpoint": "receive_paytree_std_payment",
+        "crypto": ["verify"],
+        "db_read": STORE_READS,
+        "db_write": STORE_WRITES,
+        "serialize": [
+            "model_dump_json",
+            "model_validate_json",
+            "model_validate",
+            "loads",
+            "dumps",
+        ],
+    },
+    "paytree_first_opt": {
+        "endpoint": "receive_paytree_first_opt_payment",
+        "crypto": ["verify"],
+        "db_read": STORE_READS,
+        "db_write": STORE_WRITES,
+        "serialize": ["model_dump_json", "model_validate_json", "dumps"],
+    },
+    "paytree_child_pair": {
+        "endpoint": "receive_paytree_child_pair_payment",
+        "crypto": ["verify"],
+        "db_read": STORE_READS,
+        "db_write": STORE_WRITES,
+        "serialize": ["model_dump_json", "model_validate_json", "dumps"],
+    },
+    "payword": {
+        "endpoint": "receive_payword_payment",
+        "crypto": ["verify"],
+        "db_read": STORE_READS,
+        "db_write": STORE_WRITES,
+        "serialize": [
+            "model_dump_json",
+            "model_validate_json",
+            "model_validate",
+            "loads",
+            "dumps",
+        ],
+    },
+}
+
+RUN_ENDPOINT_FUNCTION = "run_endpoint_function"
+
+VENDOR_PROFILE_QUERY = (
+    'process_cpu:cpu:nanoseconds:cpu:nanoseconds{service_name="/nanomoni-vendor-1"}'
+)

--- a/bench-plotter/src/bench_plotter/prometheus_fetch.py
+++ b/bench-plotter/src/bench_plotter/prometheus_fetch.py
@@ -19,25 +19,32 @@ import httpx
 from bench_plotter.settings import prometheus_base_url
 
 
-_SCRAPE_INTERVAL_SECONDS = 15
+_MIN_STEP_SECONDS = 5
 # Prometheus's query_range API rejects requests whose point count would exceed
 # roughly this many points per series.
 _MAX_POINTS_PER_SERIES = 11_000
 
 
 def _step_for_range_seconds(total_seconds: float) -> str:
-    """Query at the Prometheus scrape_interval (15s), widening only if needed.
+    """Query at 5s, widening only if needed.
 
-    A step finer than the scrape interval only yields duplicated (stair-stepped)
-    points and noisy rate() output, so 15s is the floor. It's also usually the
-    ceiling: coarsening the step for large windows is unnecessary noise
-    reduction for the minutes-to-hours-long windows this tool queries. But
-    Prometheus caps the number of points a query_range call may return, so for
-    a window long enough to exceed that cap at 15s, the step is widened just
-    enough to stay under it rather than letting the query fail outright.
+    5s is not a scrape interval -- it's a floor chosen to cover the tightest
+    rate() window used anywhere in this codebase: vendor-api metrics use
+    ``rate(...[10s])`` (matching that job's 1s scrape), and a step wider than
+    the window leaves a gap `rate()` never covers (window 10s, step 15s: the
+    window at t covers (t-10, t], the next at t+15 covers (t+5, t+15], so
+    (t, t+5] is never evaluated). A step no wider than the window guarantees
+    the evaluations overlap and nothing is missed. cadvisor's coarser
+    ``[1m]`` windows are unaffected -- they just get extra, harmless points at
+    this finer step. It's also usually the ceiling: coarsening the step for
+    large windows is unnecessary noise reduction for the minutes-to-hours-long
+    windows this tool queries. But Prometheus caps the number of points a
+    query_range call may return, so for a window long enough to exceed that
+    cap at 5s, the step is widened just enough to stay under it rather than
+    letting the query fail outright.
     """
-    if total_seconds <= _SCRAPE_INTERVAL_SECONDS * _MAX_POINTS_PER_SERIES:
-        return f"{_SCRAPE_INTERVAL_SECONDS}s"
+    if total_seconds <= _MIN_STEP_SECONDS * _MAX_POINTS_PER_SERIES:
+        return f"{_MIN_STEP_SECONDS}s"
     step = math.ceil(total_seconds / _MAX_POINTS_PER_SERIES)
     return f"{step}s"
 

--- a/bench-plotter/src/bench_plotter/pyroscope_fetch.py
+++ b/bench-plotter/src/bench_plotter/pyroscope_fetch.py
@@ -1,0 +1,46 @@
+"""Fetch a merged CPU profile from Pyroscope's HTTP render API.
+
+Pyroscope's ``/pyroscope/render`` selector puts the profile type as the
+leading (metric) name, not a label -- ``{service_name="...",
+profile_type="..."}`` (as shown in the Pyroscope UI) must be sent as
+``process_cpu:...{service_name="..."}``. ``format=json`` returns a
+"flamebearer" payload: a merged call tree over ``[from, until]``, not a time
+series. Flamebearer decoding lives in :mod:`bench_plotter.flamebearer`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+
+from bench_plotter.settings import pyroscope_base_url
+
+
+async def render(
+    *,
+    query: str,
+    start_unix: float,
+    end_unix: float,
+    base_url: str | None = None,
+) -> dict[str, Any]:
+    base = (base_url or pyroscope_base_url()).rstrip("/")
+    params = {
+        "query": query,
+        "from": str(int(start_unix)),
+        "until": str(int(end_unix)),
+        "format": "json",
+    }
+    url = urljoin(base + "/", "pyroscope/render")
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.get(url, params=params)
+        try:
+            payload = r.json()
+        except Exception:
+            r.raise_for_status()
+            raise
+    if "flamebearer" not in payload:
+        err = payload.get("message") or payload.get("error") or "unknown error"
+        raise ValueError(f"Pyroscope query failed: {err}")
+    return payload

--- a/bench-plotter/src/bench_plotter/saturation/__init__.py
+++ b/bench-plotter/src/bench_plotter/saturation/__init__.py
@@ -1,0 +1,5 @@
+"""Expected-vs-real TPS analysis: find a sequential client's throughput ceiling."""
+
+from .runner import generate_saturation_report
+
+__all__ = ["generate_saturation_report"]

--- a/bench-plotter/src/bench_plotter/saturation/__main__.py
+++ b/bench-plotter/src/bench_plotter/saturation/__main__.py
@@ -1,0 +1,6 @@
+"""``python -m bench_plotter.saturation`` entry point."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/bench-plotter/src/bench_plotter/saturation/aggregate.py
+++ b/bench-plotter/src/bench_plotter/saturation/aggregate.py
@@ -1,0 +1,305 @@
+"""Compare target (expected) TPS against the TPS the vendor actually served.
+
+A single NanoMoni client sends payments in one sequential ``await`` loop, so its
+throughput ceiling is ``1 / round_trip_latency``. The client's pacer only ever
+*delays* a payment -- it never reports that it fell behind (see
+``client/paytree.py``: the ``target > now`` branch is simply skipped once the
+loop is late). So a run configured for 4000 TPS that can only manage 1000 exits
+successfully and looks identical to one that hit its target.
+
+This module recovers that missing signal after the fact: for each run in a sweep
+it reads the vendor's success counter over the run window, reduces it to the
+sustained rate, and compares that to what was asked for. The highest target the
+client actually kept up with is its saturation point.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from bench_plotter.metric_queries import PAYMENT_COUNTER_METRIC_BY_MODE
+from bench_plotter.mode_style import mode_style
+from bench_plotter.prometheus_fetch import query_range
+from bench_plotter.prometheus_matrix import matrix_to_per_series_charts
+
+# A run counts as having met its target when it served at least this fraction of
+# the requested rate. Pacing is best-effort (the sleep is computed from a
+# monotonic clock, and Prometheus samples on a 15s scrape), so demanding exactly
+# 100% would flag every run as short.
+MET_TARGET_RATIO = 0.95
+
+_MAX_CONCURRENCY = 8
+
+# Rate window for the achieved-TPS query, paired with the 1s scrape interval the
+# vendor-api job sets in prometheus.yml: 10 samples per window, so a delayed
+# scrape cannot turn into a throughput dip or a no-data gap. Keeping the window
+# narrow is what allows short runs -- the floor below is a multiple of it.
+_RATE_WINDOW = "10s"
+_RATE_WINDOW_SECONDS = 10.0
+
+# Query step for the achieved-TPS range query. Overrides the module-level 15s
+# floor in prometheus_fetch, which is tuned to the global scrape interval and
+# would return only a handful of points across a short run. Deliberately coarser
+# than the 1s scrape so the series stays meaningful if the vendor is ever scraped
+# less often than prometheus.yml currently specifies.
+_QUERY_STEP = "5s"
+
+# A run whose traffic lasts less than this multiple of the rate window cannot be
+# measured with rate(): the function divides the counter increase by the whole
+# window, so a burst shorter than the window reads low by (span / window) even
+# when the client hit its target exactly. Flagged rather than silently reported.
+_MIN_SPAN_RATE_WINDOWS = 2.0
+
+
+def ideal_traffic_span_seconds(
+    total_requests: Optional[float],
+    expected_tps: float,
+) -> Optional[float]:
+    """How long a run's traffic should last if the client keeps up.
+
+    ``None`` when the timing entry lacks a request count, in which case the
+    rate-window check is skipped rather than guessed at.
+    """
+    if not total_requests or expected_tps <= 0:
+        return None
+    return float(total_requests) / expected_tps
+
+
+def rate_window_too_short(span_seconds: Optional[float]) -> bool:
+    """Whether ``rate()`` over ``_RATE_WINDOW`` can measure a run this short."""
+    if span_seconds is None:
+        return False
+    return span_seconds < _MIN_SPAN_RATE_WINDOWS * _RATE_WINDOW_SECONDS
+
+
+def achieved_tps_expr(mode: str) -> Optional[str]:
+    """PromQL for the vendor's served payment rate in ``mode``.
+
+    Returns ``None`` for a mode with no known counter, so a sweep over an
+    unrecognized mode name degrades to a missing point rather than a bad query.
+    """
+    metric = PAYMENT_COUNTER_METRIC_BY_MODE.get(mode)
+    if not metric:
+        return None
+    return f'rate({metric}{{job="vendor-api", status="success"}}[{_RATE_WINDOW}])'
+
+
+def samples_from_payload(
+    payload: Optional[Dict[str, Any]],
+) -> List[Tuple[float, float]]:
+    """Flatten a Prometheus matrix payload into ``(timestamp, value)`` pairs.
+
+    Timestamps are kept because the plateau is identified by *when* a sample was
+    taken, not by how big it is -- see :func:`plateau_samples`.
+    """
+    if not payload:
+        return []
+    charts = matrix_to_per_series_charts(payload.get("data", {}).get("result", []))
+    if not charts:
+        return []
+    chart = charts[0]
+    timestamps = chart.get("timestamps") or []
+    data = chart.get("data") or []
+    return [
+        (float(t), float(v))
+        for t, v in zip(timestamps, data)
+        if v is not None and t is not None
+    ]
+
+
+def plateau_samples(
+    samples: List[Tuple[float, float]],
+    window_seconds: float = _RATE_WINDOW_SECONDS,
+) -> List[float]:
+    """Keep only the samples whose whole rate() window sits inside the traffic.
+
+    ``rate([W])`` evaluated at ``t`` covers ``(t - W, t]``. While traffic is
+    ramping up or draining, part of that window contains no traffic at all, so the
+    sample reports a *fraction* of the real rate -- a partial-window artifact, not
+    a slow client.
+
+    Magnitude-based trimming cannot separate the two: at a 16 TPS target the last
+    ramp sample reads 13.9, which is indistinguishable from a genuine 13%
+    shortfall, and averaging it in reported 15.7 for a client that was in fact
+    pacing at exactly 16.0. Bound it by time instead. Traffic is observed from the
+    first non-zero sample ``t_a`` to the last one ``t_b``; since it may have begun
+    anywhere in ``(t_a - W, t_a]`` and ended anywhere in ``(t_b - W, t_b]``, only
+    samples in ``[t_a + W, t_b - W]`` are guaranteed fully covered.
+
+    Falls back to every active sample when the run is too short to contain a
+    fully-covered window (``rate_window_too_short`` flags that case separately).
+    """
+    active = [(t, v) for t, v in samples if v > 0]
+    if not active:
+        return []
+    first_ts, last_ts = active[0][0], active[-1][0]
+    covered = [
+        v
+        for t, v in active
+        if first_ts + window_seconds <= t <= last_ts - window_seconds
+    ]
+    return covered or [v for _, v in active]
+
+
+def sustained_rate(samples: List[Tuple[float, float]]) -> Optional[float]:
+    """Reduce a rate series to the throughput the run actually held.
+
+    Averages the fully-covered plateau. No magnitude band is applied on top: the
+    coverage rule has already removed the partial-window samples, and clipping
+    what remains would also hide genuine mid-run variation (a vendor stall, or a
+    client progressively falling behind), which is exactly what this benchmark
+    exists to surface.
+    """
+    plateau = plateau_samples(samples)
+    if not plateau:
+        return None
+    return float(np.mean(plateau))
+
+
+async def _fetch_run(
+    run: Dict[str, Any],
+    sem: asyncio.Semaphore,
+) -> Optional[Dict[str, Any]]:
+    """Resolve one run's expected vs achieved TPS."""
+    mode, tps = run.get("mode"), run.get("tps")
+    if mode is None or tps is None:
+        return None
+    ts = run.get("prometheus_timestamps", {}) or {}
+    start_ms, finish_ms = ts.get("start_ms"), ts.get("finish_ms")
+    if not start_ms or not finish_ms:
+        return None
+    expr = achieved_tps_expr(str(mode))
+    if expr is None:
+        print(f"  no known payment counter for mode {mode!r}; skipping")
+        return None
+
+    async with sem:
+        try:
+            payload = await query_range(
+                query=expr,
+                start_unix=start_ms / 1000.0,
+                end_unix=finish_ms / 1000.0,
+                step=_QUERY_STEP,
+            )
+        except Exception as exc:  # noqa: BLE001 - recorded as a missing point
+            print(f"  saturation query failed for {mode}@{tps}: {exc}")
+            payload = None
+
+    expected = float(tps)
+    achieved = sustained_rate(samples_from_payload(payload))
+    ratio = None if achieved is None or expected <= 0 else achieved / expected
+    span = ideal_traffic_span_seconds(run.get("total_requests"), expected)
+    unmeasurable = rate_window_too_short(span)
+    if unmeasurable:
+        print(
+            f"  WARNING {mode}@{tps}: only ~{span:.0f}s of traffic, shorter than "
+            f"{_MIN_SPAN_RATE_WINDOWS:.0f}x the {_RATE_WINDOW} rate window -- "
+            "achieved TPS is understated; raise RUN_DURATION_SEC"
+        )
+    return {
+        "mode": str(mode),
+        "expected_tps": expected,
+        "achieved_tps": achieved,
+        "ratio": ratio,
+        # A short run reads low by construction, so it cannot be called a
+        # shortfall -- that verdict would be an artifact of the rate window.
+        "met_target": (
+            ratio is not None and ratio >= MET_TARGET_RATIO and not unmeasurable
+        ),
+        "rate_window_too_short": unmeasurable,
+        "status": run.get("status"),
+    }
+
+
+def collect_points(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Resolve expected vs achieved TPS for every run, in sweep order."""
+
+    async def _run() -> List[Optional[Dict[str, Any]]]:
+        sem = asyncio.Semaphore(_MAX_CONCURRENCY)
+        return list(await asyncio.gather(*(_fetch_run(r, sem) for r in runs)))
+
+    points = [p for p in asyncio.run(_run()) if p is not None]
+    points.sort(key=lambda p: (p["mode"], p["expected_tps"]))
+    return points
+
+
+def saturation_tps(points: List[Dict[str, Any]], mode: str) -> Optional[float]:
+    """Highest target ``mode`` sustained: the last on-target point before falling short.
+
+    Stops at the first shortfall rather than taking the maximum on-target point
+    overall, so one anomalous high-TPS run that happens to land inside tolerance
+    cannot report a ceiling above a target the client already failed.
+    """
+    ordered = sorted(
+        (p for p in points if p["mode"] == mode), key=lambda p: p["expected_tps"]
+    )
+    ceiling: Optional[float] = None
+    for point in ordered:
+        if not point["met_target"]:
+            break
+        ceiling = point["expected_tps"]
+    return ceiling
+
+
+def build_delta_table(points: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Pivot points into a target-TPS x protocol grid of real (achieved) TPS.
+
+    Returns ``{"tps_values": [...], "modes": [...], "achieved": [[...]]}`` where
+    ``achieved[row][col]`` pairs with ``tps_values[row]`` and ``modes[col]``, and
+    is ``None`` where that combination has no measurement.
+    """
+    modes = sorted({p["mode"] for p in points})
+    tps_values = sorted({p["expected_tps"] for p in points})
+    by_cell = {(p["mode"], p["expected_tps"]): p for p in points}
+
+    achieved_grid: List[List[Optional[float]]] = []
+    for tps in tps_values:
+        row: List[Optional[float]] = []
+        for mode in modes:
+            point = by_cell.get((mode, tps))
+            row.append(point["achieved_tps"] if point else None)
+        achieved_grid.append(row)
+
+    return {"tps_values": tps_values, "modes": modes, "achieved": achieved_grid}
+
+
+def build_series(points: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """One achieved-TPS line per mode.
+
+    The ``y = x`` reference line is drawn by
+    ``plotting.sweep_renderers.create_identity_comparison_plot``, which owns the
+    axis range it has to span -- so it is deliberately not a series here.
+    """
+    series: List[Dict[str, Any]] = []
+    for mode in sorted({p["mode"] for p in points}):
+        drawable = [
+            p for p in points if p["mode"] == mode and p["achieved_tps"] is not None
+        ]
+        if not drawable:
+            continue
+        style = mode_style(mode)
+        series.append(
+            {
+                "label": f"{mode} (real)",
+                "x_values": [p["expected_tps"] for p in drawable],
+                "y_values": [p["achieved_tps"] for p in drawable],
+                "color": style["color"],
+                "marker": style["marker"],
+                "linestyle": "-",
+            }
+        )
+    return series
+
+
+def summarize(points: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the JSON summary: every point plus the per-mode saturation TPS."""
+    modes = sorted({p["mode"] for p in points})
+    return {
+        "met_target_ratio": MET_TARGET_RATIO,
+        "rate_window": _RATE_WINDOW,
+        "saturation_tps_by_mode": {m: saturation_tps(points, m) for m in modes},
+        "points": points,
+    }

--- a/bench-plotter/src/bench_plotter/saturation/cli.py
+++ b/bench-plotter/src/bench_plotter/saturation/cli.py
@@ -1,0 +1,47 @@
+"""Command-line entry point for the expected-vs-real TPS report."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare each run's target TPS against the TPS the vendor actually "
+            "served, and report the highest target a single sequential client "
+            "sustained"
+        )
+    )
+    parser.add_argument(
+        "intervals",
+        help="Path to the sweep timing JSON (e.g. tps_saturation_timing.json)",
+    )
+    parser.add_argument(
+        "--output",
+        default="plots",
+        help="Root output directory (default: plots); timestamp subdir is created inside",
+    )
+    args = parser.parse_args()
+
+    intervals_path = Path(args.intervals)
+    if not intervals_path.exists():
+        print(f"Error: {intervals_path} not found")
+        sys.exit(1)
+
+    print(f"Using timing file: {intervals_path}")
+    print(f"Output root: {args.output}")
+
+    from .runner import generate_saturation_report
+
+    written, _summary = generate_saturation_report(
+        timing_path=str(intervals_path),
+        output_root=str(args.output),
+    )
+    print(f"Saturation report complete: {len(written)} file(s) written")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench-plotter/src/bench_plotter/saturation/runner.py
+++ b/bench-plotter/src/bench_plotter/saturation/runner.py
@@ -1,0 +1,148 @@
+"""Render the expected-vs-real TPS chart and write the saturation summary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from bench_plotter.io_utils import load_timing_file, load_virtual_clients
+from bench_plotter.plotting.sweep_renderers import (
+    create_delta_table,
+    create_identity_comparison_plot,
+)
+from bench_plotter.profiling.aggregate import generate_profile_outputs
+
+from .aggregate import (
+    build_delta_table,
+    build_series,
+    collect_points,
+    saturation_tps,
+    summarize,
+)
+
+_CHART_FILENAME = "expected_vs_real_tps.png"
+_TABLE_FILENAME = "expected_vs_real_delta_table.png"
+_SUMMARY_FILENAME = "tps_saturation.json"
+
+
+def _client_config_label(virtual_clients: Optional[int]) -> str:
+    """Describe the client concurrency behind a run, for chart titles.
+
+    Each virtual client still runs its own sequential await loop (see
+    ``run_tps_saturation_sweep.sh``); only their count varies, so the wording
+    must stay accurate whether there is one or many.
+    """
+    if virtual_clients is None:
+        return "sequential client(s), count unknown"
+    if virtual_clients == 1:
+        return "single sequential client"
+    return f"{virtual_clients} virtual clients, each sequential"
+
+
+def _format_point(point: Dict[str, Any]) -> str:
+    achieved = point["achieved_tps"]
+    if achieved is None:
+        return f"  {point['mode']:>20} target {point['expected_tps']:>7.0f} -> no data"
+    if point.get("rate_window_too_short"):
+        verdict = "UNMEASURABLE (run too short)"
+    else:
+        verdict = "on target" if point["met_target"] else "SHORT"
+    return (
+        f"  {point['mode']:>20} target {point['expected_tps']:>7.0f} -> "
+        f"real {achieved:>8.1f} ({point['ratio'] * 100:5.1f}%) {verdict}"
+    )
+
+
+def generate_saturation_report(
+    timing_path: str,
+    output_root: str = "plots",
+) -> Tuple[List[str], Dict[str, Any]]:
+    """Read a sweep timing file, emit the chart + JSON summary.
+
+    Returns ``(written_paths, summary)``. Output lands in
+    ``<output_root>/<server_run_timestamp>/`` so a saturation run sits alongside
+    the regular sweep plots for the same benchmark.
+    """
+    server_ts, runs = load_timing_file(timing_path)
+    client_label = _client_config_label(load_virtual_clients(timing_path))
+    # Include failed runs: a client that dies mid-sweep is exactly the kind of
+    # result worth seeing next to the on-target points.
+    if not runs:
+        print(f"No runs found in {timing_path}")
+        return [], {}
+
+    print(f"Resolving achieved TPS for {len(runs)} run(s)...")
+    points = collect_points(runs)
+    if not points:
+        print("No achieved-TPS points resolved; nothing to plot")
+        return [], {}
+
+    for point in points:
+        print(_format_point(point))
+
+    out_dir = Path(output_root) / server_ts
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: List[str] = []
+
+    series = build_series(points)
+    if series:
+        chart_path = out_dir / _CHART_FILENAME
+        create_identity_comparison_plot(
+            series_list=series,
+            title=f"Expected vs Real TPS ({client_label})",
+            output_path=str(chart_path),
+            x_axis_label="Expected TPS (client target)",
+            y_axis_label="Real TPS (vendor, success)",
+            identity_label="y = x (real = expected)",
+        )
+        written.append(str(chart_path))
+
+    table = build_delta_table(points)
+    if table["tps_values"] and table["modes"]:
+        table_path = out_dir / _TABLE_FILENAME
+        create_delta_table(
+            tps_values=table["tps_values"],
+            modes=table["modes"],
+            achieved=table["achieved"],
+            title=(
+                "Real TPS by target and protocol "
+                f"(% = of target achieved; {client_label})"
+            ),
+            output_path=str(table_path),
+        )
+        written.append(str(table_path))
+        # create_delta_table writes a sibling CSV; record it so callers reporting
+        # "files written" do not undercount the outputs.
+        written.append(str(table_path.with_suffix(".csv")))
+
+    # Same profiling stage the full sweep runs (sweep/runner.py): the flame graph
+    # and the macro/micro split are what say *why* a mode stopped where the chart
+    # above shows it stopping. Needs tps on the run, and swallows its own errors,
+    # so an unreachable Pyroscope costs the profiles and not the report.
+    written.extend(
+        generate_profile_outputs(
+            [run for run in runs if run.get("tps") is not None],
+            output_dir=str(out_dir),
+        )
+    )
+
+    summary = summarize(points)
+    summary_path = out_dir / _SUMMARY_FILENAME
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n")
+    written.append(str(summary_path))
+    print(f"Saturation summary saved to: {summary_path}")
+
+    for mode in sorted({p["mode"] for p in points}):
+        ceiling = saturation_tps(points, mode)
+        mode_points = [p for p in points if p["mode"] == mode]
+        if ceiling is not None:
+            print(f"{mode}: max sustained target = {ceiling:.0f} TPS")
+        elif all(p.get("rate_window_too_short") for p in mode_points):
+            # Distinguish "cannot measure" from "client could not keep up": with
+            # every run shorter than the rate window, nothing was learned.
+            print(f"{mode}: no verdict -- every run was too short to measure")
+        else:
+            print(f"{mode}: fell short at every target tested")
+
+    return written, summary

--- a/bench-plotter/src/bench_plotter/settings.py
+++ b/bench-plotter/src/bench_plotter/settings.py
@@ -1,8 +1,8 @@
 """Configuration for the benchmark plotter.
 
-The Prometheus URL is intentionally hardcoded: the benchmark always runs against a
-local Prometheus on the default port. To point at a different instance, edit the
-value in ``prometheus_base_url`` below.
+The Prometheus and Pyroscope URLs are intentionally hardcoded: the benchmark
+always runs against a local stack on the default ports. To point at a
+different instance, edit the values below.
 """
 
 from __future__ import annotations
@@ -11,3 +11,8 @@ from __future__ import annotations
 def prometheus_base_url() -> str:
     """Return the (hardcoded) Prometheus base URL for the local benchmark stack."""
     return "http://127.0.0.1:9090"
+
+
+def pyroscope_base_url() -> str:
+    """Return the (hardcoded) Pyroscope base URL for the local benchmark stack."""
+    return "http://127.0.0.1:4040"

--- a/bench-plotter/src/bench_plotter/sweep/aggregate.py
+++ b/bench-plotter/src/bench_plotter/sweep/aggregate.py
@@ -9,17 +9,37 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 
 from bench_plotter.metric_queries import LATENCY_BUCKET_METRIC_BY_MODE
+
+# Re-exported (not used directly in this module beyond _series_by_mode) so
+# existing internal/test imports of these private names keep working now that
+# the implementation lives in the shared mode_style module.
+from bench_plotter.mode_style import KNOWN_MODES as _KNOWN_MODES  # noqa: F401
+from bench_plotter.mode_style import mode_style as _mode_style  # noqa: F401
+from bench_plotter.mode_style import series_by_mode as _series_by_mode
 from bench_plotter.pipeline.draw import draw_all
 from bench_plotter.pipeline.model import DrawTask
-from bench_plotter.plotting.common import PALETTE
 from bench_plotter.plotting.windowing import steady_state_samples
 from bench_plotter.prometheus_fetch import query_range
 from bench_plotter.prometheus_matrix import matrix_to_per_series_charts
+
+# The saturation sweep's own analysis found that a client asked for more TPS than
+# it can sequentially deliver still exits 0 -- e.g. a 1024 target run_benchmark.sh
+# only reached ~528 TPS for `signature`. Dividing vendor CPU by the *target* would
+# then understate mcpu_per_payment, and by a different factor per mode (whichever
+# saturates hardest looks the most "efficient"), distorting the cross-mode
+# comparison this chart exists to make. Reusing the same rate + plateau
+# extraction the saturation sweep uses keeps both call sites agreeing on what
+# "achieved TPS" means.
+from bench_plotter.saturation.aggregate import (
+    achieved_tps_expr,
+    samples_from_payload,
+    sustained_rate,
+)
 
 # PromQL reused from metric_queries/common.py (Vendor CPU / Vendor Redis CPU).
 _VENDOR_CPU_EXPR = (
@@ -28,43 +48,30 @@ _VENDOR_CPU_EXPR = (
     '    job="cadvisor",\n'
     '    container_label_com_docker_compose_service="vendor",\n'
     '    image!=""\n'
-    "  }[30s])\n"
+    "  }[1m])\n"
     ")"
 )
 _VENDOR_REDIS_CPU_EXPR = (
     "rate(container_cpu_usage_seconds_total{"
-    'job="cadvisor", name="nanomoni-redis-vendor-1", image!=""}[30s])'
+    'job="cadvisor", name="nanomoni-redis-vendor-1", image!=""}[1m])'
+)
+_CLIENT_NETWORK_OUTPUT_EXPR = (
+    "sum(\n"
+    "  rate(container_network_transmit_bytes_total{\n"
+    '    job="cadvisor",\n'
+    '    container_label_com_docker_compose_service="client",\n'
+    '    image!=""\n'
+    "  }[1m])\n"
+    ") / 1024"
 )
 
 _MAX_CONCURRENCY = 8
-
-# Stable visual identity per payment mode (sorted-mode index into the palette).
-_MODE_MARKERS = ("o", "s", "^", "D", "v", "P", "X", "*")
-_KNOWN_MODES = (
-    "paytree",
-    "paytree_first_opt",
-    "paytree_child_pair",
-    "payword",
-    "signature",
-)
-
-
-def _mode_style(mode: str) -> Dict[str, str]:
-    """Return ``{color, marker}`` for a payment mode (stable across charts)."""
-    try:
-        idx = _KNOWN_MODES.index(mode)
-    except ValueError:
-        idx = abs(hash(mode)) % len(PALETTE)
-    return {
-        "color": PALETTE[idx % len(PALETTE)],
-        "marker": _MODE_MARKERS[idx % len(_MODE_MARKERS)],
-    }
 
 
 def _latency_quantile_expr(metric: str, q: float) -> str:
     return (
         f"histogram_quantile({q}, sum(rate("
-        f'{metric}{{job="vendor-api", status="success"}}[30s])) by (le))'
+        f'{metric}{{job="vendor-api", status="success"}}[10s])) by (le))'
     )
 
 
@@ -121,24 +128,46 @@ async def _fetch_run_metrics(
     queries: Dict[str, str] = {
         "vendor_cpu": _VENDOR_CPU_EXPR,
         "vendor_redis_cpu": _VENDOR_REDIS_CPU_EXPR,
+        "client_net_output": _CLIENT_NETWORK_OUTPUT_EXPR,
     }
     if metric:
         queries["latency_p50"] = _latency_quantile_expr(metric, 0.50)
+    tps_expr = achieved_tps_expr(str(mode))
+    if tps_expr:
+        queries["achieved_tps"] = tps_expr
 
     keys = list(queries.keys())
     payloads = await asyncio.gather(
         *(_fetch_one(queries[k], start, end, sem) for k in keys)
     )
-    series = {k: _values_from_payload(p) for k, p in zip(keys, payloads)}
+    payload_by_key = dict(zip(keys, payloads))
+    series = {
+        k: _values_from_payload(p)
+        for k, p in payload_by_key.items()
+        if k != "achieved_tps"
+    }
 
     vendor_cpu_mean = _steady_mean(series.get("vendor_cpu", []))
     redis_cpu_mean = _steady_mean(series.get("vendor_redis_cpu", []))
     latency_p50 = _steady_mean(series.get("latency_p50", []))
+    client_net_output_mean = _steady_mean(series.get("client_net_output", []))
+
+    # Falls back to the target when achieved TPS can't be resolved (e.g. no
+    # counter for the mode, or too little data), rather than dropping the point.
+    achieved_tps = sustained_rate(
+        samples_from_payload(payload_by_key.get("achieved_tps"))
+    )
+    payments_per_second = achieved_tps if achieved_tps is not None else float(tps)
 
     mcpu_per_payment = None
-    if vendor_cpu_mean is not None and float(tps) > 0:
+    if vendor_cpu_mean is not None and payments_per_second > 0:
         # cores/payment * 1000 = milliCPU per payment
-        mcpu_per_payment = (vendor_cpu_mean / float(tps)) * 1000.0
+        mcpu_per_payment = (vendor_cpu_mean / payments_per_second) * 1000.0
+
+    client_net_output_kib_per_payment = None
+    if client_net_output_mean is not None and payments_per_second > 0:
+        # KiB/s / payments/s = KiB per payment
+        client_net_output_kib_per_payment = client_net_output_mean / payments_per_second
 
     return {
         "mode": mode,
@@ -147,6 +176,7 @@ async def _fetch_run_metrics(
         "vendor_cpu_mean": vendor_cpu_mean,
         "vendor_redis_cpu_mean": redis_cpu_mean,
         "mcpu_per_payment": mcpu_per_payment,
+        "client_net_output_kib_per_payment": client_net_output_kib_per_payment,
     }
 
 
@@ -154,39 +184,6 @@ async def _collect_scalars(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     sem = asyncio.Semaphore(_MAX_CONCURRENCY)
     results = await asyncio.gather(*(_fetch_run_metrics(run, sem) for run in runs))
     return [r for r in results if r is not None]
-
-
-def _series_by_mode(
-    scalars: List[Dict[str, Any]],
-    y_key: str,
-    label_suffix: str = "",
-    linestyle: str = "-",
-) -> List[Dict[str, Any]]:
-    """Group (tps, y) points by mode for one y-field, with stable mode styling."""
-    by_mode: Dict[str, List[Tuple[float, float]]] = {}
-    for row in scalars:
-        y = row.get(y_key)
-        if y is None:
-            continue
-        mode = row["mode"]
-        by_mode.setdefault(mode, []).append((row["tps"], float(y)))
-
-    series: List[Dict[str, Any]] = []
-    for mode in sorted(by_mode):
-        points = sorted(by_mode[mode], key=lambda p: p[0])
-        label = f"{mode}{label_suffix}" if label_suffix else mode
-        style = _mode_style(mode)
-        series.append(
-            {
-                "label": label,
-                "x_values": [p[0] for p in points],
-                "y_values": [p[1] for p in points],
-                "color": style["color"],
-                "marker": style["marker"],
-                "linestyle": linestyle,
-            }
-        )
-    return series
 
 
 def _latency_series(scalars: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -233,6 +230,12 @@ def build_aggregate_draw_tasks(
             "milliCPU per payment vs TPS",
             "mCPU / payment",
             _series_by_mode(scalars, "mcpu_per_payment"),
+        ),
+        (
+            "client_network_output_per_payment_vs_tps.png",
+            "Client network output per payment vs TPS",
+            "Network output (KiB) / payment",
+            _series_by_mode(scalars, "client_net_output_kib_per_payment"),
         ),
     ]
 

--- a/bench-plotter/src/bench_plotter/sweep/runner.py
+++ b/bench-plotter/src/bench_plotter/sweep/runner.py
@@ -10,35 +10,15 @@ metric-vs-TPS charts at ``plots/<timestamp>/``.
 from __future__ import annotations
 
 from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-from bench_plotter.io_utils import load_json_data
+from bench_plotter.io_utils import load_timing_file as _load_timing
 from bench_plotter.pipeline import generate_plots_from_intervals
 
+from bench_plotter.profiling.aggregate import generate_profile_outputs
+
 from .aggregate import generate_aggregate_plots
-
-
-def _load_timing(path: str) -> Tuple[str, List[Dict[str, Any]]]:
-    """Return ``(server_run_timestamp, runs)`` from a timing file.
-
-    Accepts the sweep object shape or a legacy bare list (timestamp then
-    derived from ``now``).
-    """
-    data = load_json_data(path)
-    if isinstance(data, dict):
-        ts = data.get("server_run_timestamp") or datetime.now().strftime(
-            "%Y%m%d_%H%M%S"
-        )
-        runs = data.get("runs", [])
-        if not isinstance(runs, list):
-            runs = []
-        return str(ts), [r for r in runs if isinstance(r, dict)]
-    if isinstance(data, list):
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        return ts, [r for r in data if isinstance(r, dict)]
-    return datetime.now().strftime("%Y%m%d_%H%M%S"), []
 
 
 def _successful(runs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -70,6 +50,9 @@ def _interval_for_pipeline(run: Dict[str, Any]) -> Dict[str, Any]:
         "mode": run.get("mode"),
         "status": run.get("status", "success"),
         "prometheus_timestamps": run.get("prometheus_timestamps", {}),
+        # Kept so the pipeline can turn a per-second rate into a per-payment
+        # amount (see pipeline/per_payment_table_transform.py).
+        "tps": run.get("tps"),
     }
 
 
@@ -118,6 +101,17 @@ def generate_sweep_plots(
     aggregate_runs = [r for r in runs if r.get("tps") is not None]
     written.extend(
         generate_aggregate_plots(
+            aggregate_runs,
+            output_dir=str(base),
+            workers=workers,
+            parallel=parallel,
+        )
+    )
+    # Best-effort: a down/unreachable Pyroscope must not fail the rest of the
+    # sweep, so generate_profile_outputs already swallows and logs its own
+    # errors internally.
+    written.extend(
+        generate_profile_outputs(
             aggregate_runs,
             output_dir=str(base),
             workers=workers,

--- a/bench-plotter/tests/test_flame_renderer.py
+++ b/bench-plotter/tests/test_flame_renderer.py
@@ -1,0 +1,87 @@
+"""Smoke tests for the flame-graph renderer, including the default crop to
+the ``run_endpoint_function`` subtree (see flamebearer.focus_on)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from bench_plotter.plotting.flame_renderer import create_flame_graph
+
+# names: 0 total, 1 outer, 2 run_endpoint_function, 3 receive_payment, 4 verify, 5 idle
+_NAMES = [
+    "total",
+    "outer",
+    "run_endpoint_function",
+    "receive_payment",
+    "verify",
+    "idle",
+]
+_LEVELS = [
+    [0, 100, 0, 0],
+    [0, 100, 0, 1],
+    [0, 80, 0, 2, 0, 20, 20, 5],
+    [0, 60, 0, 3],
+    [0, 10, 10, 4],
+]
+
+# Same shape but with no run_endpoint_function frame anywhere in the trace.
+_NO_ENDPOINT_NAMES = ["total", "outer", "receive_payment", "verify", "idle"]
+_NO_ENDPOINT_LEVELS = [
+    [0, 100, 0, 0],
+    [0, 100, 0, 1],
+    [0, 80, 0, 2, 0, 20, 20, 4],
+    [0, 10, 10, 3],
+]
+
+
+def _payload() -> Dict[str, Any]:
+    return {
+        "flamebearer": {
+            "names": list(_NAMES),
+            "levels": [list(lvl) for lvl in _LEVELS],
+        },
+        "metadata": {"sampleRate": 10.0},
+    }
+
+
+def _no_endpoint_payload() -> Dict[str, Any]:
+    return {
+        "flamebearer": {
+            "names": list(_NO_ENDPOINT_NAMES),
+            "levels": [list(lvl) for lvl in _NO_ENDPOINT_LEVELS],
+        },
+        "metadata": {"sampleRate": 10.0},
+    }
+
+
+class TestCreateFlameGraph:
+    def test_default_focus_crops_to_run_endpoint_function(self, tmp_path: Path) -> None:
+        out = tmp_path / "flame.png"
+        create_flame_graph(
+            _payload(),
+            title="test flame graph",
+            output_path=str(out),
+            highlight={"verify": "#eda100"},
+        )
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_focus_none_renders_full_tree(self, tmp_path: Path) -> None:
+        out = tmp_path / "flame.png"
+        create_flame_graph(_payload(), output_path=str(out), focus=None)
+        assert out.exists()
+
+    def test_focus_name_absent_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "flame.png"
+        create_flame_graph(_no_endpoint_payload(), output_path=str(out))
+        assert not out.exists()
+
+    def test_empty_levels_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "flame.png"
+        payload = {
+            "flamebearer": {"names": [], "levels": []},
+            "metadata": {"sampleRate": 10.0},
+        }
+        create_flame_graph(payload, output_path=str(out))
+        assert not out.exists()

--- a/bench-plotter/tests/test_flamebearer.py
+++ b/bench-plotter/tests/test_flamebearer.py
@@ -1,0 +1,186 @@
+"""Unit tests for flamebearer tree reconstruction and name-based tick summation.
+
+The fixture below deliberately reproduces a pattern confirmed against a live
+Pyroscope trace: ``receive_payment`` appears as both an ancestor and a
+descendant of itself (a router wrapping a same-named use-case call). Summing
+every node with a given name would double-count that nested occurrence; the
+outermost-occurrence rules under test exist specifically to avoid it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from bench_plotter.flamebearer import (
+    build_tree,
+    focus_on,
+    iter_levels,
+    outermost_nodes,
+    root_total_ticks,
+    sample_rate,
+    sum_ticks_by_name,
+    sum_ticks_within,
+)
+
+# names: 0 total, 1 outer, 2 receive_payment, 3 idle, 4 get_by_id, 5 verify, 6 get_x
+_NAMES = ["total", "outer", "receive_payment", "idle", "get_by_id", "verify", "get_x"]
+_LEVELS = [
+    [0, 100, 0, 0],
+    [0, 100, 0, 1],
+    [0, 80, 0, 2, 0, 20, 20, 3],
+    [0, 30, 0, 2, 0, 20, 20, 4],
+    [0, 10, 10, 5, 0, 5, 5, 6],
+]
+
+
+def _payload() -> Dict[str, Any]:
+    return {
+        "flamebearer": {
+            "names": list(_NAMES),
+            "levels": [list(lvl) for lvl in _LEVELS],
+        },
+        "metadata": {"sampleRate": 1_000_000_000},
+    }
+
+
+class TestBuildTree:
+    def test_reconstructs_parent_child_shape(self) -> None:
+        root = build_tree(_payload())
+        assert root.name == "total"
+        assert root.total_ticks == 100
+        assert len(root.children) == 1
+
+        outer = root.children[0]
+        assert outer.name == "outer"
+        assert [c.name for c in outer.children] == ["receive_payment", "idle"]
+
+        outer_rp, idle = outer.children
+        assert outer_rp.total_ticks == 80
+        assert idle.total_ticks == 20 and idle.self_ticks == 20
+
+        assert [c.name for c in outer_rp.children] == ["receive_payment", "get_by_id"]
+        nested_rp, get_by_id = outer_rp.children
+        assert nested_rp.total_ticks == 30
+        assert get_by_id.total_ticks == 20
+
+        assert [c.name for c in nested_rp.children] == ["verify", "get_x"]
+
+
+class TestSampleRateAndTotals:
+    def test_sample_rate(self) -> None:
+        assert sample_rate(_payload()) == 1_000_000_000.0
+
+    def test_root_total_ticks(self) -> None:
+        assert root_total_ticks(_payload()) == 100
+
+
+class TestIterLevels:
+    def test_resolves_names_and_spans(self) -> None:
+        levels = iter_levels(_payload())
+        assert levels[2] == [
+            (0, 80, 80, 0, "receive_payment"),
+            (80, 100, 20, 20, "idle"),
+        ]
+
+
+class TestOutermostNodes:
+    def test_finds_only_the_outer_occurrence(self) -> None:
+        root = build_tree(_payload())
+        nodes = outermost_nodes(root, "receive_payment")
+        assert len(nodes) == 1
+        assert nodes[0].total_ticks == 80
+
+    def test_missing_name_returns_empty(self) -> None:
+        root = build_tree(_payload())
+        assert outermost_nodes(root, "does_not_exist") == []
+
+
+class TestSumTicksByName:
+    def test_recursive_name_is_not_double_counted(self) -> None:
+        root = build_tree(_payload())
+        totals = sum_ticks_by_name(root, ["receive_payment"])
+        # Naively summing both occurrences (80 + 30) would double-count the
+        # nested one, since the outer node's total already includes it.
+        assert totals["receive_payment"] == 80
+
+    def test_sums_multiple_independent_names(self) -> None:
+        root = build_tree(_payload())
+        totals = sum_ticks_by_name(
+            root, ["receive_payment", "verify", "get_by_id", "get_x", "idle"]
+        )
+        assert totals == {
+            "receive_payment": 80,
+            "verify": 10,
+            "get_by_id": 20,
+            "get_x": 5,
+            "idle": 20,
+        }
+
+    def test_absent_name_totals_zero(self) -> None:
+        root = build_tree(_payload())
+        assert sum_ticks_by_name(root, ["nope"]) == {"nope": 0}
+
+
+class TestSumTicksWithin:
+    def test_scoped_to_given_subtrees_only(self) -> None:
+        root = build_tree(_payload())
+        endpoint_nodes = outermost_nodes(root, "receive_payment")
+        totals = sum_ticks_within(endpoint_nodes, ["verify", "get_by_id", "idle"])
+        # "idle" is a sibling of receive_payment, not inside its subtree.
+        assert totals == {"verify": 10, "get_by_id": 20, "idle": 0}
+
+
+# names: 0 total, 1 outer, 2 run_endpoint_function, 3 idle, 4 receive_payment, 5 verify
+# Two separate run_endpoint_function occurrences (two requests handled in the
+# window), each with its own receive_payment -> verify subtree, interleaved
+# with unrelated "idle" siblings -- reproduces the shape a real trimmed-window
+# profile has (many per-request subtrees scattered across a busy event loop).
+_FOCUS_NAMES = [
+    "total",
+    "outer",
+    "run_endpoint_function",
+    "idle",
+    "receive_payment",
+    "verify",
+]
+_FOCUS_LEVELS = [
+    [0, 100, 0, 0],
+    [0, 100, 0, 1],
+    [0, 30, 10, 2, 0, 10, 10, 3, 0, 30, 5, 2, 0, 30, 30, 3],
+    [0, 20, 15, 4, 20, 25, 15, 4],
+    [0, 5, 5, 5, 35, 10, 10, 5],
+]
+
+
+def _focus_payload() -> Dict[str, Any]:
+    return {
+        "flamebearer": {
+            "names": list(_FOCUS_NAMES),
+            "levels": [list(lvl) for lvl in _FOCUS_LEVELS],
+        },
+        "metadata": {"sampleRate": 10.0},
+    }
+
+
+class TestFocusOn:
+    def test_tiles_every_occurrence_from_depth_zero(self) -> None:
+        levels, total_ticks = focus_on(_focus_payload(), "run_endpoint_function")
+        assert total_ticks == 60  # 30 + 30, the two occurrences
+
+        assert levels[0] == [
+            (0, 30, 30, 10, "run_endpoint_function"),
+            (30, 60, 30, 5, "run_endpoint_function"),
+        ]
+        assert levels[1] == [
+            (0, 20, 20, 15, "receive_payment"),
+            (30, 55, 25, 15, "receive_payment"),
+        ]
+        assert levels[2] == [
+            (0, 5, 5, 5, "verify"),
+            (30, 40, 10, 10, "verify"),
+        ]
+
+    def test_missing_name_returns_empty(self) -> None:
+        levels, total_ticks = focus_on(_focus_payload(), "does_not_exist")
+        assert levels == []
+        assert total_ticks == 0

--- a/bench-plotter/tests/test_histogram_math.py
+++ b/bench-plotter/tests/test_histogram_math.py
@@ -1,0 +1,73 @@
+"""Tests for the cumulative-histogram statistics helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from bench_plotter.plotting.histogram_math import (
+    histogram_moments,
+    histogram_quantile,
+    histogram_to_samples,
+)
+
+
+class TestHistogramMoments:
+    def test_single_bucket_mean_is_its_midpoint_with_zero_spread(self) -> None:
+        # Everything in (0, 10] -> midpoint 5, and one bucket has no spread.
+        mean, stddev = histogram_moments([10.0], [1.0])
+        assert mean == pytest.approx(5.0)
+        assert stddev == pytest.approx(0.0)
+
+    def test_two_equal_buckets(self) -> None:
+        # Half in (0, 10] (midpoint 5), half in (10, 20] (midpoint 15).
+        mean, stddev = histogram_moments([10.0, 20.0], [0.5, 1.0])
+        assert mean == pytest.approx(10.0)
+        assert stddev == pytest.approx(5.0)
+
+    def test_weights_shift_the_mean_toward_the_heavier_bucket(self) -> None:
+        mean, _ = histogram_moments([10.0, 20.0], [0.9, 1.0])
+        assert mean == pytest.approx(0.9 * 5.0 + 0.1 * 15.0)
+
+    def test_counts_need_not_be_normalized(self) -> None:
+        # Raw cumulative counts must give the same answer as fractions.
+        assert histogram_moments([10.0, 20.0], [50.0, 100.0]) == histogram_moments(
+            [10.0, 20.0], [0.5, 1.0]
+        )
+
+    def test_misaligned_or_empty_input_returns_none(self) -> None:
+        assert histogram_moments([], []) == (None, None)
+        assert histogram_moments([10.0], [0.5, 1.0]) == (None, None)
+        assert histogram_moments([10.0], [0.0]) == (None, None)
+
+
+class TestHistogramQuantile:
+    def test_interpolates_inside_the_containing_bucket(self) -> None:
+        # p50 of a uniform (0, 10] bucket sits at 5.
+        assert histogram_quantile([10.0], [1.0], 0.50) == pytest.approx(5.0)
+
+    def test_median_lands_on_the_boundary_of_two_equal_buckets(self) -> None:
+        assert histogram_quantile([10.0, 20.0], [0.5, 1.0], 0.50) == pytest.approx(10.0)
+
+    def test_p95_falls_in_the_upper_bucket(self) -> None:
+        # 90% below 10, so p95 is halfway through the (10, 20] bucket.
+        assert histogram_quantile([10.0, 20.0], [0.9, 1.0], 0.95) == pytest.approx(15.0)
+
+    def test_unnormalized_cumulative_counts(self) -> None:
+        assert histogram_quantile([10.0, 20.0], [90.0, 100.0], 0.95) == pytest.approx(
+            15.0
+        )
+
+    def test_no_weight_returns_none(self) -> None:
+        assert histogram_quantile([10.0], [0.0], 0.5) is None
+        assert histogram_quantile([], [], 0.5) is None
+
+
+class TestHistogramToSamples:
+    def test_reconstructed_samples_span_the_buckets(self) -> None:
+        samples = histogram_to_samples([10.0, 20.0], [0.5, 1.0], max_total=100)
+        assert samples
+        assert min(samples) > 0.0
+        assert max(samples) <= 20.0
+
+    def test_misaligned_input_returns_empty(self) -> None:
+        assert histogram_to_samples([10.0], [0.5, 1.0]) == []

--- a/bench-plotter/tests/test_latency_transform.py
+++ b/bench-plotter/tests/test_latency_transform.py
@@ -1,0 +1,78 @@
+"""Tests for the steady-state latency transform (ECDF / violin / stats table)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from bench_plotter.pipeline.latency_transform import transform_latency_dist
+from bench_plotter.pipeline.model import PlotJob, QuerySpec, ResultCache
+
+
+def _bucket_payload(cumulative_by_le: Dict[str, float]) -> Dict[str, Any]:
+    """A bucket-rate matrix payload, flat over the window so it survives trimming."""
+    return {
+        "data": {
+            "result": [
+                {
+                    "metric": {"le": le},
+                    "values": [[float(i) * 10, str(rate)] for i in range(8)],
+                }
+                for le, rate in cumulative_by_le.items()
+            ]
+        }
+    }
+
+
+def _job(spec: QuerySpec) -> PlotJob:
+    return PlotJob(
+        kind="latency_dist",
+        title="Vendor Payment Latency",
+        output_path="plots/tps_metrics/vendor_payment_latency_ecdf.png",
+        section="tps_metrics",
+        specs=[spec],
+        params={
+            "entries": [{"mode": "payword", "spec": spec}],
+            "ecdf_path": "plots/tps_metrics/vendor_payment_latency_ecdf.png",
+            "violin_path": "plots/tps_metrics/vendor_payment_latency_violin.png",
+            "stats_path": "plots/tps_metrics/vendor_payment_latency_stats.png",
+        },
+    )
+
+
+def _tasks(cumulative_by_le: Dict[str, float]) -> List[Any]:
+    spec = QuerySpec("buckets", 0.0, 100.0)
+    cache: ResultCache = {spec: _bucket_payload(cumulative_by_le)}
+    return transform_latency_dist(_job(spec), cache)
+
+
+class TestLatencyStatsTable:
+    def test_emits_mean_stddev_and_quantiles_per_mode(self) -> None:
+        # Half the observations in (0, 10] and half in (10, 20]: bucket midpoints
+        # 5 and 15 give mean 10 and stddev 5, and the median sits on the boundary.
+        tasks = _tasks({"10": 5.0, "20": 10.0, "+Inf": 10.0})
+        stats = next(t for t in tasks if t.fn_name == "stats_table")
+
+        assert stats.output_path.endswith("vendor_payment_latency_stats.png")
+        assert stats.kwargs["col_labels"] == [
+            "mode",
+            "mean_ms",
+            "stddev_ms",
+            "p50_ms",
+            "p95_ms",
+        ]
+        (row,) = stats.kwargs["rows"]
+        mode, mean, stddev, p50, p95 = row
+        assert mode == "payword"
+        assert mean == pytest.approx(10.0)
+        assert stddev == pytest.approx(5.0)
+        assert p50 == pytest.approx(10.0)
+        assert p95 == pytest.approx(19.0)
+
+    def test_ecdf_and_violin_are_still_emitted(self) -> None:
+        fns = {t.fn_name for t in _tasks({"10": 5.0, "20": 10.0, "+Inf": 10.0})}
+        assert fns == {"bucket_ecdf", "violin", "stats_table"}
+
+    def test_no_buckets_yields_no_tasks(self) -> None:
+        assert _tasks({}) == []

--- a/bench-plotter/tests/test_per_payment_table.py
+++ b/bench-plotter/tests/test_per_payment_table.py
@@ -1,0 +1,68 @@
+"""Tests for the client-egress-per-payment table transform."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from bench_plotter.pipeline.model import PlotJob, QuerySpec, ResultCache
+from bench_plotter.pipeline.per_payment_table_transform import (
+    transform_per_payment_table,
+)
+
+
+def _payload(values: List[float]) -> Dict[str, Any]:
+    return {
+        "data": {
+            "result": [
+                {
+                    "metric": {"__name__": "m"},
+                    "values": [[float(i) * 15, str(v)] for i, v in enumerate(values)],
+                }
+            ]
+        }
+    }
+
+
+def _job(spec: QuerySpec, tps_by_mode: Dict[str, float]) -> PlotJob:
+    return PlotJob(
+        kind="per_payment_table",
+        title="Client egress per payment",
+        output_path="plots/client_resources/out_per_payment.png",
+        section="client_resources",
+        specs=[spec],
+        params={
+            "series": [{"spec": spec, "label": "payword"}],
+            "tps_by_mode": tps_by_mode,
+        },
+    )
+
+
+class TestTransformPerPaymentTable:
+    def test_divides_egress_rate_by_the_payment_rate(self) -> None:
+        # A flat 512 KiB/s plateau at 256 payments/s is 2 KiB (2048 bytes) of
+        # request on the wire per payment.
+        spec = QuerySpec("client_egress", 0.0, 100.0)
+        cache: ResultCache = {spec: _payload([512.0] * 8)}
+
+        tasks = transform_per_payment_table(_job(spec, {"payword": 256.0}), cache)
+
+        assert len(tasks) == 1
+        assert tasks[0].fn_name == "stats_table"
+        (row,) = tasks[0].kwargs["rows"]
+        mode, tps, kib_s, kib_per_payment, bytes_per_payment = row
+        assert mode == "payword"
+        assert tps == pytest.approx(256.0)
+        assert kib_s == pytest.approx(512.0)
+        assert kib_per_payment == pytest.approx(2.0)
+        assert bytes_per_payment == pytest.approx(2048.0)
+
+    def test_mode_without_a_known_tps_is_skipped(self) -> None:
+        spec = QuerySpec("client_egress", 0.0, 100.0)
+        cache: ResultCache = {spec: _payload([512.0] * 8)}
+        assert transform_per_payment_table(_job(spec, {}), cache) == []
+
+    def test_missing_payload_yields_no_task(self) -> None:
+        spec = QuerySpec("client_egress", 0.0, 100.0)
+        assert transform_per_payment_table(_job(spec, {"payword": 256.0}), {}) == []

--- a/bench-plotter/tests/test_pipeline.py
+++ b/bench-plotter/tests/test_pipeline.py
@@ -3,7 +3,7 @@
 import os
 import pickle
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 
@@ -14,23 +14,24 @@ from bench_plotter.pipeline.plan import build_plan
 from bench_plotter.pipeline.fetch import _unique_specs
 
 
-def _intervals(modes: List[str]) -> List[Dict[str, Any]]:
+def _intervals(modes: List[str], tps: Optional[int] = None) -> List[Dict[str, Any]]:
     out = []
     for i, mode in enumerate(modes):
         start = 1_000_000 + i * 1000
-        out.append(
-            {
-                "mode": mode,
-                "status": "success",
-                "prometheus_timestamps": {"start_ms": start, "finish_ms": start + 600},
-            }
-        )
+        interval: Dict[str, Any] = {
+            "mode": mode,
+            "status": "success",
+            "prometheus_timestamps": {"start_ms": start, "finish_ms": start + 600},
+        }
+        if tps is not None:
+            interval["tps"] = tps
+        out.append(interval)
     return out
 
 
-def _plan_paths(modes: List[str]) -> set:
+def _plan_paths(modes: List[str], tps: Optional[int] = None) -> set:
     """All figure output paths the plan implies, expanding multi-output jobs."""
-    intervals = _intervals(modes)
+    intervals = _intervals(modes, tps)
     charts = get_charts_for_modes(set(modes))
     jobs = build_plan(intervals, charts, output_dir="plots")
     paths = set()
@@ -41,8 +42,8 @@ def _plan_paths(modes: List[str]) -> set:
             for key in ("ecdf_path", "violin_path"):
                 paths.add(os.path.relpath(job.params[key], "plots"))
         if job.kind == "latency_dist":
-            paths.add("tps_metrics/vendor_payment_latency_ecdf.png")
-            paths.add("tps_metrics/vendor_payment_latency_violin.png")
+            for key in ("ecdf_path", "violin_path", "stats_path"):
+                paths.add(os.path.relpath(job.params[key], "plots"))
     return paths
 
 
@@ -88,12 +89,21 @@ PAYWORD_CONTRACT = {
     "tps_metrics/vendor_payment_latency_boxplot.png",
     "tps_metrics/vendor_payment_latency_ecdf.png",
     "tps_metrics/vendor_payment_latency_violin.png",
+    "tps_metrics/vendor_payment_latency_stats.png",
 }
+
+# Dividing a rate by the payment rate that drove it needs the run's tps, which
+# only a sweep-built plan carries.
+PER_PAYMENT_PATH = "client_resources/client_network_kib_s_output_per_payment.png"
 
 
 class TestBuildPlan:
     def test_payword_only_path_set(self) -> None:
         assert _plan_paths(["payword"]) == PAYWORD_CONTRACT
+
+    def test_per_payment_table_only_when_intervals_carry_tps(self) -> None:
+        assert PER_PAYMENT_PATH not in _plan_paths(["payword"])
+        assert PER_PAYMENT_PATH in _plan_paths(["payword"], tps=256)
 
     def test_only_present_modes_are_queried(self) -> None:
         # A payword-only plan must not reference other modes' metrics.
@@ -161,6 +171,7 @@ class TestDrawContract:
             "precomputed_box",
             "bucket_ecdf",
             "sweep_line",
+            "stats_table",
         }
         assert expected_fns <= set(DRAW_REGISTRY)
 

--- a/bench-plotter/tests/test_profile_bar_renderer.py
+++ b/bench-plotter/tests/test_profile_bar_renderer.py
@@ -1,0 +1,101 @@
+"""Tests for the per-TPS macro/micro bar chart and the combined table PNG+CSV."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Dict, List
+
+from bench_plotter.plotting.profile_bar_renderer import (
+    create_macro_micro_bar,
+    create_macro_micro_table,
+)
+
+
+def _record(mode: str, tps: float, **overrides: float) -> Dict[str, Any]:
+    base = {
+        "mode": mode,
+        "tps": tps,
+        "total_time_s": 10.0,
+        "run_endpoint_time_s": 9.0,
+        "macro_time_s": 8.0,
+        "crypto_time_s": 2.0,
+        "db_read_time_s": 1.2,
+        "db_write_time_s": 0.8,
+        "serialize_time_s": 1.0,
+        "other_time_s": 3.0,
+        "profile_payments": 8000.0,
+        "crypto_ms_per_payment": 0.25,
+        "db_read_ms_per_payment": 0.15,
+        "db_write_ms_per_payment": 0.1,
+        "serialize_ms_per_payment": 0.125,
+        "other_ms_per_payment": 0.375,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCreateMacroMicroBar:
+    def test_writes_one_png_per_call_no_csv(self, tmp_path: Path) -> None:
+        records: List[Dict[str, Any]] = [
+            _record("signature", 200.0),
+            _record("paytree", 200.0),
+        ]
+        out = tmp_path / "profile_macro_micro_tps200.png"
+        create_macro_micro_bar(records, output_path=str(out))
+
+        assert out.exists()
+        assert not out.with_suffix(".csv").exists()
+
+    def test_no_records_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "profile_macro_micro_tps200.png"
+        create_macro_micro_bar([], output_path=str(out))
+        assert not out.exists()
+
+    def test_records_without_a_payment_count_are_skipped(self, tmp_path: Path) -> None:
+        # Bars are per payment, so a run whose payment count couldn't be read
+        # has nothing to normalize by and cannot be drawn.
+        record = _record("signature", 200.0)
+        record.update(
+            profile_payments=None,
+            crypto_ms_per_payment=None,
+            db_read_ms_per_payment=None,
+            db_write_ms_per_payment=None,
+            serialize_ms_per_payment=None,
+            other_ms_per_payment=None,
+        )
+        out = tmp_path / "profile_macro_micro_tps200.png"
+        create_macro_micro_bar([record], output_path=str(out))
+        assert not out.exists()
+
+
+class TestCreateMacroMicroTable:
+    def test_writes_png_and_csv(self, tmp_path: Path) -> None:
+        records: List[Dict[str, Any]] = [
+            _record("signature", 200.0),
+            _record("paytree", 200.0),
+            _record("signature", 300.0),
+            _record("paytree", 300.0),
+        ]
+        out = tmp_path / "profile_macro_micro_table.png"
+        create_macro_micro_table(records, output_path=str(out))
+
+        assert out.exists()
+        csv_path = out.with_suffix(".csv")
+        assert csv_path.exists()
+
+        rows = list(csv.DictReader(open(csv_path)))
+        assert len(rows) == 4
+        by_key = {(r["mode"], r["tps"]): r for r in rows}
+        row = by_key[("signature", "200.0")]
+        assert float(row["macro_time_s"]) == 8.0
+        assert float(row["crypto_time_s"]) == 2.0
+        assert float(row["db_read_time_s"]) == 1.2
+        assert float(row["db_write_time_s"]) == 0.8
+        assert float(row["serialize_time_s"]) == 1.0
+
+    def test_no_records_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "profile_macro_micro_table.png"
+        create_macro_micro_table([], output_path=str(out))
+        assert not out.exists()
+        assert not out.with_suffix(".csv").exists()

--- a/bench-plotter/tests/test_profiling_aggregate.py
+++ b/bench-plotter/tests/test_profiling_aggregate.py
@@ -1,0 +1,284 @@
+"""Unit tests for the per-run Pyroscope profile extraction (profiling/aggregate.py)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bench_plotter.profiling.aggregate import (
+    _extract_record,
+    _fetch_run_profile,
+    _highlight_for_mode,
+    build_profile_draw_tasks,
+)
+from bench_plotter.plotting.profile_bar_renderer import (
+    _CRYPTO_COLOR,
+    _DB_READ_COLOR,
+    _DB_WRITE_COLOR,
+    _SERIALIZE_COLOR,
+)
+
+# A signature-mode request: the endpoint calls crypto, a repository read that
+# issues one mget, and a repository write that serializes then runs a script.
+# The nested mget mimics redis-py's same-named method inside our store's.
+_NAMES = [
+    "total",
+    "run_endpoint_function",
+    "receive_payment",
+    "idle",
+    "verify_signature_bytes",
+    "get_by_channel_id",
+    "save_payment",
+    "mget",
+    "model_dump_json",
+    "run_script",
+]
+_LEVELS = [
+    [0, 100, 0, 0],
+    [0, 100, 0, 1],
+    [0, 80, 40, 2, 0, 20, 20, 3],
+    # verify(10) + get_by_channel_id(15) + save_payment(15)
+    [0, 10, 10, 4, 0, 15, 3, 5, 0, 15, 2, 6],
+    # mget(12) under get_by_channel_id; model_dump_json(3) + run_script(10)
+    # under save_payment
+    [10, 12, 4, 7, 3, 3, 3, 8, 0, 10, 10, 9],
+    # redis-py's own mget(8) nested inside our store's mget
+    [10, 8, 8, 7],
+]
+
+
+def _payload(sample_rate: float = 10.0) -> Dict[str, Any]:
+    return {
+        "flamebearer": {
+            "names": list(_NAMES),
+            "levels": [list(lvl) for lvl in _LEVELS],
+        },
+        "metadata": {"sampleRate": sample_rate},
+    }
+
+
+def _counter_payload(values: Optional[List[float]]) -> Dict[str, Any]:
+    """A Prometheus query_range payload for a single series.
+
+    ``values`` is the raw counter reading at each of a few evenly spaced
+    timestamps -- callers only care about the first-vs-last delta.
+    ``None`` mimics "no data returned" (e.g. an unrecognized mode/metric).
+    """
+    if values is None:
+        return {"data": {"result": []}}
+    return {
+        "data": {
+            "result": [
+                {
+                    "metric": {"__name__": "payment_requests_total"},
+                    "values": [[1000.0 + i, str(v)] for i, v in enumerate(values)],
+                }
+            ]
+        }
+    }
+
+
+def _run(
+    mode: str = "signature",
+    tps: float = 200.0,
+    start_ms: int = 1_000_000,
+    finish_ms: int = 1_100_000,
+) -> Dict[str, Any]:
+    return {
+        "mode": mode,
+        "tps": tps,
+        "total_requests": 12000,
+        "prometheus_timestamps": {"start_ms": start_ms, "finish_ms": finish_ms},
+    }
+
+
+class TestExtractRecord:
+    def test_computes_macro_micro_split(self) -> None:
+        # sampleRate=10: ticks/10 = seconds. crypto=10, db read=mget(12) with
+        # the nested mget(8) counted once, db write=run_script(10), serialize=3,
+        # other = 80 - 10 - 12 - 10 - 3 = 45. The repository frames themselves
+        # (get_by_channel_id, save_payment) are not a bucket of their own, so
+        # their non-I/O, non-marshalling time falls into other.
+        record = _extract_record(_payload(), "signature", 200.0)
+        assert record["total_time_s"] == pytest.approx(10.0)
+        assert record["run_endpoint_time_s"] == pytest.approx(10.0)
+        assert record["macro_time_s"] == pytest.approx(8.0)
+        assert record["crypto_time_s"] == pytest.approx(1.0)
+        assert record["db_read_time_s"] == pytest.approx(1.2)
+        assert record["db_write_time_s"] == pytest.approx(1.0)
+        assert record["serialize_time_s"] == pytest.approx(0.3)
+        assert record["other_time_s"] == pytest.approx(4.5)
+
+    def test_unknown_mode_raises(self) -> None:
+        with pytest.raises(KeyError):
+            _extract_record(_payload(), "not_a_real_mode", 200.0)
+
+
+class TestHighlightForMode:
+    def test_maps_crypto_db_and_serialize_functions_to_shared_colors(self) -> None:
+        highlight = _highlight_for_mode("signature")
+        assert highlight["verify_signature_bytes"] == _CRYPTO_COLOR
+        assert highlight["mget"] == _DB_READ_COLOR
+        assert highlight["run_script"] == _DB_WRITE_COLOR
+        assert highlight["model_dump_json"] == _SERIALIZE_COLOR
+
+
+async def _call(run: Dict[str, Any]) -> Any:
+    # A Semaphore constructed outside a running loop binds to whatever loop
+    # asyncio.get_event_loop() resolves to on Python 3.9, which can be a
+    # stale/closed one left by an earlier test's asyncio.run(); creating it
+    # inside the coroutine that asyncio.run() drives avoids that entirely.
+    sem = asyncio.Semaphore(1)
+    return await _fetch_run_profile(run, sem)
+
+
+_QUERY_RANGE = "bench_plotter.profiling.aggregate.query_range"
+_RENDER = "bench_plotter.profiling.aggregate.pyroscope_fetch.render"
+
+
+class TestFetchRunProfile:
+    def test_missing_mode_or_tps_returns_none(self) -> None:
+        run = _run()
+        del run["mode"]
+        assert asyncio.run(_call(run)) is None
+
+    def test_mode_not_in_taxonomy_returns_none(self) -> None:
+        assert asyncio.run(_call(_run(mode="unknown"))) is None
+
+    def test_missing_window_returns_none(self) -> None:
+        run = _run()
+        run["prometheus_timestamps"] = {}
+        assert asyncio.run(_call(run)) is None
+
+    @patch(_QUERY_RANGE, new_callable=AsyncMock)
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_successful_fetch_builds_record(
+        self, mock_render: AsyncMock, mock_query_range: AsyncMock
+    ) -> None:
+        mock_render.return_value = _payload()
+        mock_query_range.return_value = _counter_payload([0.0, 9000.0])
+        record = asyncio.run(_call(_run()))
+        assert record is not None
+        assert record["mode"] == "signature"
+        assert record["tps"] == 200.0
+        assert record["total_requests"] == 12000
+        assert record["macro_time_s"] == pytest.approx(8.0)
+
+        # The run's whole window is queried, untrimmed: the harness's pre-run
+        # sleep and post-run drain already leave idle margins inside it, and
+        # starting later would truncate the payment counter's delta.
+        _, kwargs = mock_render.call_args
+        assert kwargs["start_unix"] == pytest.approx(1000.0)
+        assert kwargs["end_unix"] == pytest.approx(1100.0)
+
+        # The payment count comes from the vendor's own counter over exactly
+        # that same window, not a TPS/total_requests model.
+        _, qkwargs = mock_query_range.call_args
+        assert qkwargs["start_unix"] == pytest.approx(1000.0)
+        assert qkwargs["end_unix"] == pytest.approx(1100.0)
+        assert "payment_requests_total" in mock_query_range.call_args.kwargs["query"]
+
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_query_failure_returns_none(self, mock_render: AsyncMock) -> None:
+        mock_render.side_effect = ValueError("pyroscope down")
+        assert asyncio.run(_call(_run())) is None
+
+    @patch(_QUERY_RANGE, new_callable=AsyncMock)
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_prometheus_failure_propagates(
+        self, mock_render: AsyncMock, mock_query_range: AsyncMock
+    ) -> None:
+        # Unlike a down Pyroscope, a down Prometheus must not be swallowed
+        # into a None/skipped-run result: every per-payment number this stage
+        # produces depends on the payment count it would have supplied, so a
+        # wrong (modeled) number is worse than surfacing the failure.
+        mock_render.return_value = _payload()
+        mock_query_range.side_effect = ValueError("prometheus unreachable")
+        with pytest.raises(ValueError, match="prometheus unreachable"):
+            asyncio.run(_call(_run()))
+
+    @patch(_QUERY_RANGE, new_callable=AsyncMock)
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_per_payment_fields_use_the_vendor_counter_delta(
+        self, mock_render: AsyncMock, mock_query_range: AsyncMock
+    ) -> None:
+        mock_render.return_value = _payload()
+        mock_query_range.return_value = _counter_payload([100.0, 9100.0])
+        record = asyncio.run(_call(_run()))
+        assert record is not None
+        assert record["profile_payments"] == pytest.approx(9000.0)
+        assert record["crypto_ms_per_payment"] == pytest.approx(1.0 / 9000 * 1000)
+        assert record["db_read_ms_per_payment"] == pytest.approx(1.2 / 9000 * 1000)
+        assert record["db_write_ms_per_payment"] == pytest.approx(1.0 / 9000 * 1000)
+        assert record["serialize_ms_per_payment"] == pytest.approx(0.3 / 9000 * 1000)
+        assert record["other_ms_per_payment"] == pytest.approx(4.5 / 9000 * 1000)
+
+    @patch(_QUERY_RANGE, new_callable=AsyncMock)
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_per_payment_is_none_when_counter_has_no_data(
+        self, mock_render: AsyncMock, mock_query_range: AsyncMock
+    ) -> None:
+        mock_render.return_value = _payload()
+        mock_query_range.return_value = _counter_payload(None)
+        record = asyncio.run(_call(_run()))
+        assert record is not None
+        assert record["profile_payments"] is None
+        assert record["crypto_ms_per_payment"] is None
+
+
+class TestBuildProfileDrawTasks:
+    @patch(_QUERY_RANGE, new_callable=AsyncMock)
+    @patch(_RENDER, new_callable=AsyncMock)
+    def test_task_shape_for_two_tps_levels(
+        self,
+        mock_render: AsyncMock,
+        mock_query_range: AsyncMock,
+        tmp_path: Any,
+    ) -> None:
+        mock_render.return_value = _payload()
+        mock_query_range.return_value = _counter_payload([0.0, 9000.0])
+        runs = [
+            _run(mode="signature", tps=200.0),
+            _run(mode="signature", tps=300.0),
+        ]
+        tasks = build_profile_draw_tasks(runs, str(tmp_path))
+        by_fn: Dict[str, list] = {}
+        for t in tasks:
+            by_fn.setdefault(t.fn_name, []).append(t)
+
+        # One flame graph per run, each cropped to the mode's own endpoint
+        # (receive_payment for signature), not the generic FastAPI wrapper.
+        assert len(by_fn["flame_graph"]) == 2
+        for t in by_fn["flame_graph"]:
+            assert t.kwargs["focus"] == "receive_payment"
+
+        # One bar chart PER TPS, written inside that TPS's own profile folder
+        # alongside that config's flame graphs.
+        assert len(by_fn["profile_macro_micro_bar"]) == 2
+        bar_paths = {t.output_path for t in by_fn["profile_macro_micro_bar"]}
+        for tps in (200, 300):
+            assert (
+                str(
+                    tmp_path
+                    / f"tps{tps}_req12000"
+                    / "profile"
+                    / "profile_macro_micro.png"
+                )
+                in bar_paths
+            )
+
+        # One combined table (CSV + PNG).
+        assert len(by_fn["profile_macro_micro_table"]) == 1
+
+        # Absolute and per-payment vs-TPS line charts, per micro category.
+        categories = ("crypto", "db_read", "db_write", "serialize", "other")
+        assert len(by_fn["sweep_line"]) == 2 * len(categories)
+        line_paths = {t.output_path for t in by_fn["sweep_line"]}
+        for category in categories:
+            assert str(tmp_path / f"{category}_time_vs_tps.png") in line_paths
+            assert str(tmp_path / f"{category}_time_per_payment_vs_tps.png") in (
+                line_paths
+            )

--- a/bench-plotter/tests/test_prometheus_fetch.py
+++ b/bench-plotter/tests/test_prometheus_fetch.py
@@ -14,24 +14,25 @@ from bench_plotter.prometheus_matrix import (
 
 class TestStepForRangeSeconds:
     def test_small_window(self) -> None:
-        # Step is the 15s scrape_interval for any window under Prometheus's
-        # per-series point cap.
-        assert _step_for_range_seconds(300) == "15s"
+        # Step is the 5s floor (covers the 10s vendor-api rate() window with
+        # no gap) for any window under Prometheus's per-series point cap.
+        assert _step_for_range_seconds(300) == "5s"
 
     def test_medium_window(self) -> None:
-        assert _step_for_range_seconds(3600) == "15s"
+        assert _step_for_range_seconds(3600) == "5s"
 
     def test_large_window(self) -> None:
-        assert _step_for_range_seconds(24 * 3600) == "15s"
+        # 12h stays under the new (5s-floor) point cap of ~15.3h.
+        assert _step_for_range_seconds(12 * 3600) == "5s"
 
-    def test_window_at_point_cap_stays_15s(self) -> None:
-        # 11_000 points * 15s == 165_000s: right at the cap, still 15s.
-        assert _step_for_range_seconds(11_000 * 15) == "15s"
+    def test_window_at_point_cap_stays_5s(self) -> None:
+        # 11_000 points * 5s == 55_000s: right at the cap, still 5s.
+        assert _step_for_range_seconds(11_000 * 5) == "5s"
 
     def test_window_over_point_cap_widens_step(self) -> None:
         # Beyond the cap the step widens just enough to stay under it, rather
         # than letting Prometheus reject the query with too many points.
-        assert _step_for_range_seconds(48 * 3600) == "16s"
+        assert _step_for_range_seconds(16 * 3600) == "6s"
 
 
 class TestQueryRange:

--- a/bench-plotter/tests/test_pyroscope_fetch.py
+++ b/bench-plotter/tests/test_pyroscope_fetch.py
@@ -1,0 +1,40 @@
+"""Tests for pyroscope_fetch module."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from bench_plotter.pyroscope_fetch import render
+
+
+class TestRender:
+    @patch("bench_plotter.pyroscope_fetch.httpx.AsyncClient")
+    def test_successful_query(self, mock_client: MagicMock) -> None:
+        mock_response = AsyncMock()
+        mock_response.json = Mock(
+            return_value={"flamebearer": {"names": [], "levels": []}}
+        )
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=mock_response
+        )
+
+        result = asyncio.run(
+            render(
+                query="process_cpu:cpu:nanoseconds:cpu:nanoseconds{}",
+                start_unix=1000.0,
+                end_unix=2000.0,
+            )
+        )
+        assert result == {"flamebearer": {"names": [], "levels": []}}
+
+    @patch("bench_plotter.pyroscope_fetch.httpx.AsyncClient")
+    def test_query_failure_raises(self, mock_client: MagicMock) -> None:
+        mock_response = AsyncMock()
+        mock_response.json = Mock(return_value={"message": "profile-type required"})
+        mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+            return_value=mock_response
+        )
+
+        with pytest.raises(ValueError, match="profile-type required"):
+            asyncio.run(render(query="bad", start_unix=1000.0, end_unix=2000.0))

--- a/bench-plotter/tests/test_saturation.py
+++ b/bench-plotter/tests/test_saturation.py
@@ -1,0 +1,471 @@
+"""Unit tests for the expected-vs-real TPS (saturation) analysis."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from bench_plotter.draw_worker import DRAW_REGISTRY
+from bench_plotter.io_utils import load_timing_file, load_virtual_clients
+from bench_plotter.plotting import sweep_renderers
+from bench_plotter.plotting.sweep_renderers import (
+    create_delta_table,
+    create_identity_comparison_plot,
+)
+from bench_plotter.saturation.aggregate import (
+    MET_TARGET_RATIO,
+    achieved_tps_expr,
+    build_delta_table,
+    build_series,
+    ideal_traffic_span_seconds,
+    plateau_samples,
+    rate_window_too_short,
+    saturation_tps,
+    summarize,
+    sustained_rate,
+)
+from bench_plotter.saturation import runner
+from bench_plotter.saturation.runner import _client_config_label
+
+
+def _point(
+    mode: str,
+    expected: float,
+    achieved: Optional[float],
+) -> Dict[str, Any]:
+    ratio = None if achieved is None else achieved / expected
+    return {
+        "mode": mode,
+        "expected_tps": expected,
+        "achieved_tps": achieved,
+        "ratio": ratio,
+        "met_target": ratio is not None and ratio >= MET_TARGET_RATIO,
+        "status": "success",
+    }
+
+
+class TestAchievedTpsExpr:
+    def test_uses_the_modes_own_counter(self) -> None:
+        expr = achieved_tps_expr("paytree_child_pair")
+        assert expr is not None
+        assert "paytree_child_pair_payment_requests_total" in expr
+        assert 'status="success"' in expr
+        assert "[10s]" in expr
+
+    def test_signature_uses_bare_counter_name(self) -> None:
+        expr = achieved_tps_expr("signature")
+        assert expr is not None
+        assert expr.startswith("rate(payment_requests_total{")
+
+    def test_unknown_mode_has_no_query(self) -> None:
+        assert achieved_tps_expr("not_a_mode") is None
+
+
+def _samples(values: List[float], step: float = 5.0) -> List[Any]:
+    """Attach evenly spaced timestamps, as a 5s-step range query returns."""
+    return [(i * step, v) for i, v in enumerate(values)]
+
+
+class TestPlateauSamples:
+    def test_drops_ramp_and_drain_partial_windows(self) -> None:
+        # The exact shape a 16 TPS run produces: two ramp samples, a flat plateau,
+        # one drain sample. Only the plateau is fully covered by the rate window.
+        values = [0.0, 5.0, 13.9, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 11.0]
+        assert plateau_samples(_samples(values), window_seconds=10.0) == [16.0] * 6
+
+    def test_a_ramp_sample_near_the_plateau_is_still_dropped(self) -> None:
+        # 13.9 is only 13% under the plateau, so no magnitude band can exclude it
+        # without also excluding a real 13% shortfall. Time coverage can.
+        values = [0.0, 5.0, 13.9, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 11.0]
+        assert 13.9 not in plateau_samples(_samples(values), window_seconds=10.0)
+
+    def test_keeps_genuine_mid_run_variation(self) -> None:
+        # A dip inside the covered region is real (vendor stall, or the client
+        # progressively falling behind) and must survive.
+        values = [0.0, 100.0, 500.0, 508.0, 508.0, 300.0, 508.0, 508.0, 250.0, 0.0]
+        kept = plateau_samples(_samples(values), window_seconds=10.0)
+        assert 300.0 in kept
+
+    def test_falls_back_when_nothing_is_fully_covered(self) -> None:
+        # Traffic shorter than 2x the window leaves no covered sample; report the
+        # active ones rather than nothing (rate_window_too_short flags this run).
+        values = [0.0, 200.0, 210.0, 0.0]
+        assert plateau_samples(_samples(values), window_seconds=10.0) == [200.0, 210.0]
+
+    def test_no_traffic(self) -> None:
+        assert plateau_samples(_samples([0.0, 0.0, 0.0])) == []
+        assert plateau_samples([]) == []
+
+
+class TestSustainedRate:
+    def test_reports_the_plateau_exactly(self) -> None:
+        # Previously this averaged the 13.9 ramp sample in and reported 15.74 for a
+        # client that was pacing at exactly 16.0.
+        values = [0.0, 5.0, 13.9, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 16.0, 11.0]
+        assert sustained_rate(_samples(values)) == pytest.approx(16.0)
+
+    def test_ignores_setup_and_drain_zeros(self) -> None:
+        # A PayTree run sends nothing while the tree is built, then drains to 0.
+        values = [0.0, 0.0, 0.0, 250.0, 500.0, 500.0, 500.0, 500.0, 500.0, 200.0, 0.0]
+        rate = sustained_rate(_samples(values))
+        assert rate == pytest.approx(500.0)
+
+    def test_short_run_falls_back_to_active_samples(self) -> None:
+        assert sustained_rate(_samples([0.0, 200.0, 210.0])) == pytest.approx(205.0)
+
+    def test_no_traffic_yields_none(self) -> None:
+        assert sustained_rate(_samples([0.0, 0.0, 0.0])) is None
+        assert sustained_rate([]) is None
+
+
+class TestRateWindowGuard:
+    def test_span_is_count_over_target(self) -> None:
+        assert ideal_traffic_span_seconds(2880, 64) == pytest.approx(45.0)
+        assert ideal_traffic_span_seconds(122880, 1024) == pytest.approx(120.0)
+
+    def test_span_unknown_without_a_count(self) -> None:
+        assert ideal_traffic_span_seconds(None, 64) is None
+        assert ideal_traffic_span_seconds(0, 64) is None
+
+    def test_burst_shorter_than_two_rate_windows_is_unmeasurable(self) -> None:
+        # Traffic shorter than the window reads low by (span / window) no matter
+        # what the client did -- the trap that produced a bogus SHORT verdict.
+        assert rate_window_too_short(10.0) is True
+        assert rate_window_too_short(19.0) is True
+
+    def test_long_enough_run_is_measurable(self) -> None:
+        # The sweep's 45s default sits comfortably above the 20s floor.
+        assert rate_window_too_short(20.0) is False
+        assert rate_window_too_short(45.0) is False
+
+    def test_unknown_span_is_not_flagged(self) -> None:
+        assert rate_window_too_short(None) is False
+
+
+class TestSaturationTps:
+    def test_last_on_target_before_shortfall(self) -> None:
+        points = [
+            _point("signature", 16, 16.0),
+            _point("signature", 32, 32.0),
+            _point("signature", 64, 63.5),
+            _point("signature", 128, 70.0),
+        ]
+        assert saturation_tps(points, "signature") == 64
+
+    def test_stops_at_first_shortfall(self) -> None:
+        # 1024 lands inside tolerance by luck; the ceiling must not jump past the
+        # 256 target the client already failed.
+        points = [
+            _point("signature", 128, 128.0),
+            _point("signature", 256, 150.0),
+            _point("signature", 1024, 1024.0),
+        ]
+        assert saturation_tps(points, "signature") == 128
+
+    def test_none_when_even_the_lowest_target_falls_short(self) -> None:
+        points = [_point("signature", 16, 4.0)]
+        assert saturation_tps(points, "signature") is None
+
+    def test_scoped_per_mode(self) -> None:
+        points = [
+            _point("signature", 64, 64.0),
+            _point("paytree_child_pair", 64, 20.0),
+        ]
+        assert saturation_tps(points, "signature") == 64
+        assert saturation_tps(points, "paytree_child_pair") is None
+
+
+class TestBuildSeries:
+    def test_one_line_per_mode_and_no_reference_line(self) -> None:
+        points = [
+            _point("signature", 16, 16.0),
+            _point("signature", 32, 30.0),
+            _point("payword", 16, 15.0),
+            _point("payword", 32, 20.0),
+        ]
+        series = build_series(points)
+        # The y = x line belongs to the renderer, which knows the axis range it
+        # must span; only measured series come from here.
+        assert [s["label"] for s in series] == ["payword (real)", "signature (real)"]
+        assert series[1]["x_values"] == [16, 32]
+        assert series[1]["y_values"] == [16.0, 30.0]
+
+    def test_modes_get_distinct_colors(self) -> None:
+        points = [_point("signature", 16, 16.0), _point("payword", 16, 15.0)]
+        colors = {s["color"] for s in build_series(points)}
+        assert len(colors) == 2
+
+    def test_drops_points_without_data(self) -> None:
+        points = [_point("signature", 16, 16.0), _point("signature", 32, None)]
+        series = build_series(points)
+        assert series[0]["x_values"] == [16]
+
+    def test_empty_when_nothing_drawable(self) -> None:
+        assert build_series([_point("signature", 16, None)]) == []
+
+
+class TestBuildDeltaTable:
+    def test_rows_are_targets_and_columns_are_protocols(self) -> None:
+        points = [
+            _point("signature", 16, 16.0),
+            _point("signature", 32, 30.0),
+            _point("payword", 16, 12.0),
+            _point("payword", 32, 20.0),
+        ]
+        table = build_delta_table(points)
+        assert table["tps_values"] == [16, 32]
+        assert table["modes"] == ["payword", "signature"]
+        # achieved[row][col] == real TPS for tps_values[row] and modes[col]
+        assert table["achieved"] == [
+            [pytest.approx(12.0), pytest.approx(16.0)],
+            [pytest.approx(20.0), pytest.approx(30.0)],
+        ]
+
+    def test_missing_measurement_is_none_not_zero(self) -> None:
+        # A None cell must stay distinguishable from a genuine achieved value of 0.
+        points = [_point("signature", 16, None), _point("signature", 32, 32.0)]
+        achieved = build_delta_table(points)["achieved"]
+        assert achieved[0][0] is None
+        assert achieved[1][0] == pytest.approx(32.0)
+
+    def test_absent_mode_tps_combination_is_none(self) -> None:
+        # payword was only swept at 16, signature only at 32.
+        points = [_point("payword", 16, 15.0), _point("signature", 32, 30.0)]
+        table = build_delta_table(points)
+        assert table["modes"] == ["payword", "signature"]
+        assert table["achieved"] == [
+            [pytest.approx(15.0), None],
+            [None, pytest.approx(30.0)],
+        ]
+
+    def test_empty_points(self) -> None:
+        table = build_delta_table([])
+        assert table == {"tps_values": [], "modes": [], "achieved": []}
+
+
+class TestDeltaTableRenderer:
+    def test_in_registry(self) -> None:
+        assert "delta_table" in DRAW_REGISTRY
+
+    def test_writes_png_and_csv(self, tmp_path: Path) -> None:
+        out = tmp_path / "delta.png"
+        create_delta_table(
+            tps_values=[16, 32],
+            modes=["signature", "payword"],
+            achieved=[[16.0, 12.0], [30.0, None]],
+            output_path=str(out),
+        )
+        csv_path = out.with_suffix(".csv")
+        assert out.exists() and out.stat().st_size > 0
+        assert csv_path.exists()
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[0] == ["Target TPS", "signature", "payword"]
+        assert rows[1] == ["16", "16.0 (100.0%)", "12.0 (75.0%)"]
+        # Missing cell renders as a placeholder, never as a number.
+        assert rows[2] == ["32", "30.0 (93.8%)", "-"]
+
+    def test_overshoot_is_above_100_percent(self, tmp_path: Path) -> None:
+        out = tmp_path / "delta.png"
+        create_delta_table(
+            tps_values=[100],
+            modes=["signature"],
+            achieved=[[102.5]],
+            output_path=str(out),
+        )
+        rows = list(csv.reader(out.with_suffix(".csv").open()))
+        assert rows[1] == ["100", "102.5 (102.5%)"]
+
+    def test_no_output_without_data(self, tmp_path: Path) -> None:
+        out = tmp_path / "delta.png"
+        create_delta_table(tps_values=[], modes=[], achieved=[], output_path=str(out))
+        assert not out.exists()
+
+
+class TestIdentityComparisonRenderer:
+    def test_in_registry(self) -> None:
+        assert "identity_comparison" in DRAW_REGISTRY
+
+    def test_writes_png(self, tmp_path: Path) -> None:
+        out = tmp_path / "identity.png"
+        create_identity_comparison_plot(
+            series_list=[
+                {
+                    "label": "signature (real)",
+                    "x_values": [16, 32, 64, 128],
+                    "y_values": [16.0, 32.0, 63.0, 70.0],
+                }
+            ],
+            output_path=str(out),
+        )
+        assert out.exists() and out.stat().st_size > 0
+
+    def test_axes_share_scale_limits_and_ticks(self, tmp_path: Path) -> None:
+        # The whole point of the chart: y = x must render as a true diagonal, so
+        # both axes need one scale, one range, and one set of ticks.
+        captured: Dict[str, Any] = {}
+        real_save = sweep_renderers.save_figure
+
+        def _capture(fig: Any, output_path: str, **kwargs: Any) -> None:
+            ax = fig.axes[0]
+            captured["xscale"] = ax.get_xscale()
+            captured["yscale"] = ax.get_yscale()
+            captured["xlim"] = ax.get_xlim()
+            captured["ylim"] = ax.get_ylim()
+            captured["xticks"] = list(ax.get_xticks())
+            captured["yticks"] = list(ax.get_yticks())
+            captured["aspect"] = ax.get_aspect()
+            real_save(fig, output_path, **kwargs)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sweep_renderers, "save_figure", _capture)
+            create_identity_comparison_plot(
+                series_list=[
+                    {
+                        "label": "signature (real)",
+                        "x_values": [16, 32, 64],
+                        "y_values": [16.0, 30.0, 40.0],
+                    }
+                ],
+                output_path=str(tmp_path / "identity.png"),
+            )
+
+        assert captured["xscale"] == captured["yscale"] == "log"
+        assert captured["xlim"] == captured["ylim"]
+        assert captured["xticks"] == captured["yticks"]
+        assert captured["aspect"] == 1.0
+
+    def test_skips_non_positive_points(self, tmp_path: Path) -> None:
+        # Log axes cannot represent 0; such a point is dropped, not clipped.
+        out = tmp_path / "identity.png"
+        create_identity_comparison_plot(
+            series_list=[
+                {"label": "signature", "x_values": [16, 32], "y_values": [0.0, 30.0]}
+            ],
+            output_path=str(out),
+        )
+        assert out.exists()
+
+    def test_no_output_without_drawable_series(self, tmp_path: Path) -> None:
+        out = tmp_path / "identity.png"
+        create_identity_comparison_plot(series_list=[], output_path=str(out))
+        assert not out.exists()
+
+        create_identity_comparison_plot(
+            series_list=[{"label": "s", "x_values": [16], "y_values": [0.0]}],
+            output_path=str(out),
+        )
+        assert not out.exists()
+
+
+class TestSummarize:
+    def test_reports_ceiling_per_mode(self) -> None:
+        points = [
+            _point("signature", 16, 16.0),
+            _point("signature", 32, 20.0),
+        ]
+        summary = summarize(points)
+        assert summary["saturation_tps_by_mode"] == {"signature": 16}
+        assert summary["met_target_ratio"] == MET_TARGET_RATIO
+        assert summary["rate_window"] == "10s"
+        assert summary["points"] == points
+
+
+class TestLoadTimingFile:
+    def test_reads_sweep_object_shape(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        runs: List[Dict[str, Any]] = [{"mode": "signature", "tps": 16}]
+        path.write_text(
+            json.dumps({"server_run_timestamp": "20260730_120000", "runs": runs})
+        )
+        ts, loaded = load_timing_file(str(path))
+        assert ts == "20260730_120000"
+        assert loaded == runs
+
+    def test_reads_legacy_bare_list(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        path.write_text(json.dumps([{"mode": "signature", "tps": 16}]))
+        ts, loaded = load_timing_file(str(path))
+        assert ts  # derived from now()
+        assert len(loaded) == 1
+
+    def test_tolerates_unexpected_shapes(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        path.write_text(json.dumps({"runs": "not-a-list"}))
+        _ts, loaded = load_timing_file(str(path))
+        assert loaded == []
+
+
+class TestLoadVirtualClients:
+    def test_reads_virtual_clients_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        path.write_text(json.dumps({"runs": [], "virtual_clients": 8}))
+        assert load_virtual_clients(str(path)) == 8
+
+    def test_none_when_field_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        path.write_text(json.dumps({"runs": []}))
+        assert load_virtual_clients(str(path)) is None
+
+    def test_none_for_legacy_bare_list(self, tmp_path: Path) -> None:
+        path = tmp_path / "timing.json"
+        path.write_text(json.dumps([{"mode": "signature", "tps": 16}]))
+        assert load_virtual_clients(str(path)) is None
+
+
+class TestSaturationReportProfiling:
+    def test_profiles_through_the_same_stage_as_the_full_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        timing = tmp_path / "timing.json"
+        timing.write_text(
+            json.dumps(
+                {
+                    "server_run_timestamp": "20260801_120000",
+                    "virtual_clients": 48,
+                    "runs": [
+                        {"mode": "signature", "tps": 4096, "status": "success"},
+                        {"mode": "payword", "status": "success"},
+                    ],
+                }
+            )
+        )
+        seen: Dict[str, Any] = {}
+
+        def _profile(runs: List[Dict[str, Any]], output_dir: str) -> List[str]:
+            seen["runs"] = runs
+            seen["output_dir"] = output_dir
+            return [str(Path(output_dir) / "flame_signature.png")]
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                runner,
+                "collect_points",
+                lambda _runs: [_point("signature", 4096, 4000.0)],
+            )
+            mp.setattr(runner, "generate_profile_outputs", _profile)
+            written, _summary = runner.generate_saturation_report(
+                timing_path=str(timing),
+                output_root=str(tmp_path / "plots"),
+            )
+
+        out_dir = tmp_path / "plots" / "20260801_120000"
+        # A run without tps has no place on the sweep's axis, so it is not profiled.
+        assert [run["mode"] for run in seen["runs"]] == ["signature"]
+        assert seen["output_dir"] == str(out_dir)
+        assert str(out_dir / "flame_signature.png") in written
+
+
+class TestClientConfigLabel:
+    def test_singular_for_one_client(self) -> None:
+        assert _client_config_label(1) == "single sequential client"
+
+    def test_plural_for_many_clients(self) -> None:
+        assert _client_config_label(8) == "8 virtual clients, each sequential"
+
+    def test_unknown_when_absent(self) -> None:
+        assert _client_config_label(None) == "sequential client(s), count unknown"

--- a/bench-plotter/tests/test_settings.py
+++ b/bench-plotter/tests/test_settings.py
@@ -4,7 +4,7 @@ import os
 from unittest.mock import patch
 
 
-from bench_plotter.settings import prometheus_base_url
+from bench_plotter.settings import prometheus_base_url, pyroscope_base_url
 
 
 class TestPrometheusBaseUrl:
@@ -21,3 +21,11 @@ class TestPrometheusBaseUrl:
             os.environ, {"PROMETHEUS_URL": "http://prometheus.example.com:8080"}
         ):
             assert prometheus_base_url() == "http://127.0.0.1:9090"
+
+
+class TestPyroscopeBaseUrl:
+    """The Pyroscope base URL is intentionally hardcoded, same as Prometheus's."""
+
+    def test_default_url(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            assert pyroscope_base_url() == "http://127.0.0.1:4040"

--- a/bench-plotter/tests/test_sweep.py
+++ b/bench-plotter/tests/test_sweep.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any, Dict
@@ -12,12 +13,33 @@ from bench_plotter.draw_worker import DRAW_REGISTRY
 from bench_plotter.plotting.common import PALETTE
 from bench_plotter.plotting.sweep_renderers import create_sweep_line_plot
 from bench_plotter.plotting.windowing import steady_state_samples
-from bench_plotter.sweep.aggregate import _latency_series, _mode_style, _series_by_mode
+from bench_plotter.sweep import aggregate as sweep_aggregate
+from bench_plotter.sweep.aggregate import (
+    _fetch_run_metrics,
+    _latency_series,
+    _mode_style,
+    _series_by_mode,
+)
 from bench_plotter.sweep.runner import (
     config_dirname,
     group_runs_by_config,
     generate_sweep_plots,
 )
+
+
+def _matrix_payload(values: list[tuple[float, float]]) -> Dict[str, Any]:
+    """Build a query_range-shaped payload from (timestamp, value) pairs."""
+    return {
+        "status": "success",
+        "data": {
+            "result": [
+                {
+                    "metric": {"__name__": "series"},
+                    "values": [[t, str(v)] for t, v in values],
+                }
+            ]
+        },
+    }
 
 
 def _run(
@@ -81,6 +103,79 @@ class TestSteadyStateReduce:
         assert all(0.8 <= v <= 1.2 for v in samples)
 
 
+class TestMcpuPerPaymentUsesAchievedTps:
+    def test_divides_by_achieved_not_target_when_client_falls_short(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The saturation sweep found that a client asked for 1024 TPS can settle
+        # at ~512 while still exiting 0. Dividing vendor CPU by the 1024 target
+        # would then understate mcpu_per_payment by ~2x -- and by a different
+        # factor per mode, distorting the cross-mode comparison this chart makes.
+        vendor_cpu = 0.5  # cores
+        achieved = 512.0  # real TPS, half of the 1024 target
+
+        async def fake_query_range(
+            *, query: str, start_unix: float, end_unix: float, step: str | None = None
+        ) -> Dict[str, Any]:
+            if "container_cpu_usage_seconds_total" in query and "redis" not in query:
+                return _matrix_payload([(0.0, vendor_cpu)] * 6)
+            if "requests_total" in query:
+                # Flat plateau covering the whole window -> sustained_rate == achieved.
+                return _matrix_payload([(float(i * 5), achieved) for i in range(8)])
+            return _matrix_payload([])
+
+        monkeypatch.setattr(sweep_aggregate, "query_range", fake_query_range)
+
+        run = {
+            "mode": "signature",
+            "tps": 1024,
+            "prometheus_timestamps": {"start_ms": 1_000, "finish_ms": 46_000},
+        }
+
+        async def _run() -> Any:
+            # The semaphore must be constructed inside the coroutine asyncio.run
+            # drives: built as a bare argument, Semaphore.__init__ binds to the
+            # current event loop eagerly (Python 3.9), which doesn't exist yet.
+            return await _fetch_run_metrics(run, asyncio.Semaphore(1))
+
+        result = asyncio.run(_run())
+
+        assert result is not None
+        expected_mcpu = (vendor_cpu / achieved) * 1000.0
+        wrong_mcpu_if_using_target = (vendor_cpu / 1024.0) * 1000.0
+        assert result["mcpu_per_payment"] == pytest.approx(expected_mcpu)
+        assert result["mcpu_per_payment"] != pytest.approx(wrong_mcpu_if_using_target)
+
+    def test_falls_back_to_target_when_achieved_tps_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vendor_cpu = 0.1
+
+        async def fake_query_range(
+            *, query: str, start_unix: float, end_unix: float, step: str | None = None
+        ) -> Dict[str, Any]:
+            if "container_cpu_usage_seconds_total" in query and "redis" not in query:
+                return _matrix_payload([(0.0, vendor_cpu)] * 6)
+            # No payment traffic resolvable (e.g. Prometheus query failed).
+            return _matrix_payload([])
+
+        monkeypatch.setattr(sweep_aggregate, "query_range", fake_query_range)
+
+        run = {
+            "mode": "signature",
+            "tps": 64,
+            "prometheus_timestamps": {"start_ms": 1_000, "finish_ms": 46_000},
+        }
+
+        async def _run() -> Any:
+            return await _fetch_run_metrics(run, asyncio.Semaphore(1))
+
+        result = asyncio.run(_run())
+
+        assert result is not None
+        assert result["mcpu_per_payment"] == pytest.approx((vendor_cpu / 64.0) * 1000.0)
+
+
 class TestSweepLineRenderer:
     def test_sweep_line_in_registry(self) -> None:
         assert "sweep_line" in DRAW_REGISTRY
@@ -135,12 +230,13 @@ class TestSweepLineRenderer:
 
 class TestModeStyle:
     def test_known_modes_get_stable_palette_slots(self) -> None:
+        # Slot = position in KNOWN_MODES, so every chart gives a mode the same hue.
         paytree = _mode_style("paytree")
         payword = _mode_style("payword")
         signature = _mode_style("signature")
         assert paytree["color"] == PALETTE[0]
-        assert payword["color"] == PALETTE[1]
-        assert signature["color"] == PALETTE[2]
+        assert payword["color"] == PALETTE[3]
+        assert signature["color"] == PALETTE[4]
         assert paytree["marker"] != payword["marker"]
 
     def test_series_by_mode_attaches_style(self) -> None:
@@ -154,7 +250,7 @@ class TestModeStyle:
         by_label = {s["label"]: s for s in series}
         assert by_label["paytree"]["color"] == PALETTE[0]
         assert by_label["paytree"]["linestyle"] == "-"
-        assert by_label["signature"]["color"] == PALETTE[2]
+        assert by_label["signature"]["color"] == PALETTE[4]
 
     def test_latency_series_p50_only(self) -> None:
         scalars = [
@@ -168,7 +264,7 @@ class TestModeStyle:
         assert by_label["paytree"]["y_values"] == [0.5, 0.4]
         assert "y_low" not in by_label["paytree"]
         assert by_label["paytree"]["color"] == PALETTE[0]
-        assert by_label["signature"]["color"] == PALETTE[2]
+        assert by_label["signature"]["color"] == PALETTE[4]
 
 
 class TestGenerateSweepPlotsLoad:
@@ -188,7 +284,7 @@ class TestGenerateSweepPlotsLoad:
             )
         )
 
-        # Avoid hitting Prometheus / drawing heavy per-config charts.
+        # Avoid hitting Prometheus / Pyroscope / drawing heavy per-config charts.
         monkeypatch.setattr(
             "bench_plotter.sweep.runner.generate_plots_from_intervals",
             lambda *a, **k: [],
@@ -196,6 +292,10 @@ class TestGenerateSweepPlotsLoad:
         monkeypatch.setattr(
             "bench_plotter.sweep.runner.generate_aggregate_plots",
             lambda *a, **k: [str(tmp_path / "agg.png")],
+        )
+        monkeypatch.setattr(
+            "bench_plotter.sweep.runner.generate_profile_outputs",
+            lambda *a, **k: [],
         )
 
         written = generate_sweep_plots(

--- a/bench-plotter/tests/test_table_renderer.py
+++ b/bench-plotter/tests/test_table_renderer.py
@@ -1,0 +1,51 @@
+"""Tests for the shared table figure + CSV renderer."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from bench_plotter.plotting.table_renderer import create_stats_table, format_cell
+
+
+class TestFormatCell:
+    def test_missing_renders_as_placeholder(self) -> None:
+        assert format_cell(None) == "-"
+
+    def test_floats_use_three_significant_figures(self) -> None:
+        assert format_cell(1.23456) == "1.23"
+        assert format_cell(0.000123456) == "0.000123"
+
+    def test_large_numbers_never_use_scientific_notation(self) -> None:
+        # These cells are compared digit-for-digit against their neighbours, so
+        # "1.74e+03" beside "938" would defeat the whole point of the column.
+        assert format_cell(247296.0) == "247296"
+        assert format_cell(1739.21) == "1739"
+
+    def test_strings_pass_through(self) -> None:
+        assert format_cell("signature") == "signature"
+
+
+class TestCreateStatsTable:
+    def test_writes_png_and_csv_with_raw_values(self, tmp_path: Path) -> None:
+        out = tmp_path / "stats.png"
+        create_stats_table(
+            col_labels=["mode", "mean_ms", "stddev_ms"],
+            rows=[["signature", 1.23456789, 0.5], ["payword", 2.0, None]],
+            title="Latency",
+            output_path=str(out),
+        )
+
+        assert out.exists()
+        csv_path = out.with_suffix(".csv")
+        rows = list(csv.DictReader(open(csv_path)))
+        assert [r["mode"] for r in rows] == ["signature", "payword"]
+        # The CSV keeps full precision; only the PNG rounds for display.
+        assert rows[0]["mean_ms"] == "1.23456789"
+        assert rows[1]["stddev_ms"] == ""
+
+    def test_no_rows_writes_nothing(self, tmp_path: Path) -> None:
+        out = tmp_path / "stats.png"
+        create_stats_table(col_labels=["mode"], rows=[], output_path=str(out))
+        assert not out.exists()
+        assert not out.with_suffix(".csv").exists()

--- a/docs/benchmark-ceiling-and-what-remains.md
+++ b/docs/benchmark-ceiling-and-what-remains.md
@@ -1,0 +1,175 @@
+# Where the benchmark stops, and what would move it
+
+This closes the round of work that
+[worker-affinity-and-saturation.md](worker-affinity-and-saturation.md) records. That
+document follows the investigation in the order it happened, from the first ceiling
+at 3900 TPS to the current one, and holds the derivation of every number below. This
+one states where the system stands, which component holds each mode, and what each
+remaining barrier requires from whoever picks this up.
+
+The layout under measurement: an AMD EPYC 9224, 24 physical cores, one uvicorn
+worker per vendor core on its own listening port, one Redis per side, the load
+generator pinned beside them. [tuning.md](../tuning.md) holds the core map and the
+host-level tuning.
+
+---
+
+## 1. What holds each mode
+
+Sustained rates from a sweep at a target of 16384 TPS, and the plateau of that same
+sweep sampled by `scripts/probe-saturation.py`:
+
+| mode | sustained TPS | plateau TPS | vendor | generator | redis serving thread | vendor µs/payment |
+|---|---|---|---|---|---|---|
+| payword | 12557.6 | 12753 | 11.85/12 | 3.56/4 | 0.96 | 929 |
+| paytree | 11688.5 | 11909 | 7.74/12 | 2.51/4 | 0.91 | 650 |
+| paytree_first_opt | 9761.4 | 9299 | 10.48/12 | 2.98/4 | 0.98 | 1127 |
+| paytree_child_pair | 9672.9 | 10020 | 10.10/12 | 2.86/4 | 1.01 | 1008 |
+| signature | 7806.6 | 8190 | 11.97/12 | 2.27/4 | 0.20 | 1462 |
+
+The serving thread of `redis-vendor` executes every command on one core, and it
+holds the four paytree and payword modes: between 0.91 and 1.01 of the one core it
+can use, with the vendor leaving between 0.2 and 4.3 cores unused behind it.
+`signature` is the exception — Redis sits at 0.20 while the vendor holds 11.97 of 12 cores, so
+verifying a signature is what limits it.
+
+Each ceiling sits at the inverse of what a payment costs the serving thread: 75 µs
+allows 13.3k and payword reached 12.6k, 106 µs allows 9.4k and `first_opt` reached
+9.8k. What the Lua script writes sets that cost. `paytree` and `payword` issue 3
+`SET`s per payment and their `EVALSHA` costs 24 µs; `paytree_child_pair` and
+`paytree_first_opt` issue 5 `SET`s and 2 `ZADD`s, and their `EVALSHA` costs 37 and
+43 µs. The ranking the sweep reports per scheme reduces to the number of keys that
+scheme's script writes.
+
+Latency separates the two situations. payword spreads its work over three components
+at 89-99% and holds p99 at 2.9 ms. `first_opt` funnels through one thread at 0.98
+and sits at p50 3.5 ms with p99 11.9 ms — the queue in front of a component that
+runs one command at a time.
+
+---
+
+## 2. The core budget is spent
+
+All 24 physical cores carry an assignment: the vendor's twelve workers on
+`1-10,19-20`, its Redis on `11,18`, the generator's four processes on `12-14,21`, the
+issuer on `16` beside its Redis on `17`, monitoring on `22-23`, and `0` plus `15` for
+housekeeping and interrupts. What remains unassigned is the SMT siblings at `N+24`,
+which share execution units with the core they sit on, so they do not add a core to
+give.
+
+Two constraints close the arithmetic. The 3:1 vendor-to-generator rule means a core
+given to the vendor draws 1.33 cores, because the generator grows with it or binds
+first — `signature` at 6219 TPS was a generator reading, not a server one. And the
+two cores left in the monitoring block buy nothing for `paytree_first_opt` or
+`paytree_child_pair`, which already leave vendor cores idle while queueing on one
+Redis thread.
+
+So the loop that raises the ceiling by widening a cpuset ended on this box. The last
+round of it moved three cores and bought 21-26% for payword, paytree and signature
+while paying 8% and 6% for the two modes that were already Redis-bound.
+
+---
+
+## 3. What a payment costs the vendor
+
+The plotter's profiling stage reads the merged Pyroscope profile over each run's
+plateau and writes `profile_macro_micro_table.csv`. Applying its shares to the CPU
+per payment above gives where a payment's microseconds go inside the vendor. The
+shares come from the middle 70% of the run and the totals from a 12s plateau window,
+so the split assumes the mix holds across the plateau.
+
+| mode | µs/payment | above the handler | crypto | redis calls | unattributed inside |
+|---|---|---|---|---|---|
+| payword | 929 | 544 | 16 | 292 | 70 |
+| paytree | 650 | 360 | 49 | 193 | 45 |
+| paytree_child_pair | 1008 | 581 | 18 | 276 | 127 |
+| paytree_first_opt | 1127 | 637 | 26 | 301 | 154 |
+| signature | 1462 | 795 | 290 | 281 | 93 |
+
+Above the handler sits the ASGI path: HTTP parsing, routing, dependency resolution,
+response serialization, the event loop. It takes more CPU than the Redis calls in
+every mode, and more than signature verification in the mode that verifies
+signatures. The flame graphs name what fills it — the widest frames by self time are
+CPython's own, `_PyEval_EvalFrameDefault`, `_PyFunction_Vectorcall`,
+`_PyType_Lookup`, both above the handler and inside it, which is also what the
+unattributed column is made of. The vendor runs Python 3.9 (`pyproject.toml` pins
+`>=3.9,<3.10.0`), so the specializing interpreter of 3.11 and later has never been
+under this measurement.
+
+---
+
+## 4. Two barriers remain, and they differ in kind from the earlier ones
+
+Five ceilings preceded these, and four of them were interference: load held away
+from capacity that existed, or CPU spent outside the measured path. The shared
+`aiohttp` pool spread one channel's payments over several workers. A shared accept
+socket left 7 workers at the ceiling of their core and 2 under 10%. The AOF rewrite
+child burned the other half of Redis's core on the keyspace earlier runs left
+behind, which also moved `EVALSHA` from 36 to 72 µs. One ceiling was a constant in a
+shell script. None of them was the price of the design: fixing them lowered what a
+payment cost the box without changing what the scheme asks for.
+
+The two that remain are the price of the design, and each needs a different kind of
+change.
+
+**The serving thread of `redis-vendor`.** No core buys anything here: one thread
+executes every command. Two paths out. Cut what a payment writes, which section 1
+prices directly — the modes rank by their `SET` and `ZADD` count, so the scheme with
+fewer writes moves first. Or give the problem more than one thread, which means more
+than one instance: `infrastructure/database.py` holds a single `database_url` and all
+twelve workers connect to it, so sharding is a code change that routes by key, not an
+environment variable.
+
+**The fixed cost of an HTTP request in the vendor.** It binds `signature` now and
+forms the floor for the other four the moment Redis leaves the front. Raising the
+interpreter attacks the widest frames without touching the protocol, and the pin at
+`<3.10.0` is the first thing to check there. Amortizing the fixed cost — more than
+one payment per request — attacks the whole layer above the handler, which is 544 to
+795 µs of every payment.
+
+---
+
+## 5. What this means for comparing the schemes
+
+The comparison the benchmark exists to make is between payment schemes, and the
+schemes account for a fraction of what the box spends. `signature` spends 290 µs of
+1462 on crypto. The four paytree and payword modes spend 16 to 49 µs of 650 to 1127
+on it, and 193 to 301 µs in Redis. Everything else belongs to the harness — the
+framework above the handler, the interpreter inside it.
+
+Two consequences for how results get reported. TPS states the size of the box as
+much as the cost of the scheme, so CPU per payment is the figure that carries across
+machines, and it is what sections 1 and 3 report. And the ranking survives the
+overhead while the absolute numbers do not: the four paytree and payword modes order
+themselves by the writes their script performs, which belongs to the scheme, whereas
+what each of them costs is set by Python and Starlette. A gap between two schemes
+narrower than that overhead has no reading yet.
+
+---
+
+## 6. What to trust when measuring this
+
+Three readings agreed on every figure that decided something here: `mpstat` per
+core, the in-container probe over `/proc`, and cadvisor through Prometheus. One
+disagreed — `docker stats --no-stream` reported the vendor at 6.6% of one core during
+the runs in section 1, while the other three put it above 11 cores.
+
+A container total hides the distribution inside it, and twice in this investigation
+the container sat at its limit while the process doing the work did not. Any ceiling
+diagnosed from a cgroup total needs the split behind it: per worker, per command,
+per core.
+
+In `commandstats`, a command called from Lua is counted on its own *and* inside the
+`EVALSHA` that called it, so the two cannot be added.
+
+Reproduction commands for all of the above live in section 11 of
+[worker-affinity-and-saturation.md](worker-affinity-and-saturation.md). The two that
+produce the tables here:
+
+```sh
+poetry run python scripts/probe-saturation.py 12          # one plateau, attributed
+poetry run python -m bench_plotter.saturation tps_saturation_timing.json
+```
+
+The second writes the expected-vs-real chart, the ceiling per mode, the macro/micro
+CPU table, and one flame graph per mode into `plots/<timestamp>/`.

--- a/grafana/dashboards/overview.json
+++ b/grafana/dashboards/overview.json
@@ -1562,7 +1562,7 @@
           "refId": "A"
         }
       ],
-      "title": "Issuer Redis CPU Usage (Cores)",
+      "title": "Vendor Redis CPU Usage (Cores)",
       "type": "timeseries"
     },
     {
@@ -1664,7 +1664,7 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "rate(payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -1675,7 +1675,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(payment_requests_total{job=\"vendor-api\", status=\"client_error\"}[1m])",
+          "expr": "rate(payment_requests_total{job=\"vendor-api\", status=\"client_error\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1688,7 +1688,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(payword_payment_requests_total{job=\"vendor-api\", status=\"client_error\"}[1m])",
+          "expr": "rate(payword_payment_requests_total{job=\"vendor-api\", status=\"client_error\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1701,7 +1701,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(payword_payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(payword_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1714,7 +1714,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(paytree_std_payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(paytree_std_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1727,7 +1727,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(paytree_std_payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(paytree_std_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1740,7 +1740,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(paytree_first_opt_payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(paytree_first_opt_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1753,12 +1753,38 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "rate(paytree_first_opt_payment_requests_total{job=\"vendor-api\", status=\"success\"}[1m])",
+          "expr": "rate(paytree_first_opt_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "af7qj924y8ohsc"
+          },
+          "editorMode": "code",
+          "expr": "rate(paytree_child_pair_payment_requests_total{job=\"vendor-api\", status=\"success\"}[10s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Paytree Child-Pair",
+          "range": true,
+          "refId": "I"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "af7qj924y8ohsc"
+          },
+          "editorMode": "code",
+          "expr": "rate(paytree_child_pair_payment_requests_total{job=\"vendor-api\", status=\"client_error\"}[10s])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Paytree Child-Pair (client_error)",
+          "range": true,
+          "refId": "J"
         }
       ],
       "title": "Vendor Payment TPS (success)",
@@ -1854,7 +1880,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.99,\n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(\n  0.99,\n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Signature P99",
@@ -1867,7 +1893,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, \n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.95, \n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Signature P95",
@@ -1880,7 +1906,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, \n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.50, \n  sum(rate(payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Signature P50",
@@ -1893,7 +1919,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.99, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Payword P99",
@@ -1906,7 +1932,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.95, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Payword P95",
@@ -1919,7 +1945,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.50, \n  sum(rate(payword_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Payword P50",
@@ -1932,7 +1958,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.99, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Paytree P99",
@@ -1945,7 +1971,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.95, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Paytree P95",
@@ -1958,7 +1984,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.50, \n  sum(rate(paytree_std_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "Paytree P50",
@@ -1971,7 +1997,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.50, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1984,7 +2010,7 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.95, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
@@ -1997,12 +2023,51 @@
             "uid": "af7qj924y8ohsc"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[1m])) by (le)\n)",
+          "expr": "histogram_quantile(0.99, \n  sum(rate(paytree_first_opt_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
           "hide": false,
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "L"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "af7qj924y8ohsc"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, \n  sum(rate(paytree_child_pair_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Paytree Child-Pair P99",
+          "range": true,
+          "refId": "M"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "af7qj924y8ohsc"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, \n  sum(rate(paytree_child_pair_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Paytree Child-Pair P95",
+          "range": true,
+          "refId": "N"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "af7qj924y8ohsc"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, \n  sum(rate(paytree_child_pair_payment_request_duration_milliseconds_bucket{job=\"vendor-api\", status=\"success\"}[10s])) by (le)\n)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "Paytree Child-Pair P50",
+          "range": true,
+          "refId": "O"
         }
       ],
       "title": "Vendor Payment Duration Average (ms)",

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -6,7 +6,16 @@ scrape_configs:
     static_configs:
       - targets: ['cadvisor:8080']
 
+  # Scraped far faster than the 15s global default so the saturation sweep can
+  # measure achieved TPS with rate(...[10s]) -- 10 samples per window -- and keep
+  # benchmark runs short. rate() needs >= 2 samples in its window (4+ to be
+  # robust), so the scrape interval is what sets the minimum usable run length.
+  # scrape_timeout must be <= scrape_interval or Prometheus refuses to start; the
+  # global default is 10s, so it is overridden here too. Measured cost: the
+  # vendor renders /metrics in ~6ms (267 series), i.e. ~0.6% of its CPU at 1s.
   - job_name: 'vendor-api'
+    scrape_interval: 1s
+    scrape_timeout: 900ms
     static_configs:
       - targets: ['vendor:8000']
 

--- a/run_quick_benchmark.sh
+++ b/run_quick_benchmark.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Quick variant of run_benchmark.sh: only sweeps 200 and 300 TPS, with
+# shortened durations/gaps. Trades measurement precision for a much shorter
+# total run time (useful for smoke-testing the benchmark pipeline itself).
+#
+# For each TPS the client sends (TPS * RUN_DURATION_SEC) payments paced at
+# 1/TPS, yielding ~RUN_DURATION_SEC seconds of traffic.
+TPS_VALUES=(200 300)
+RUN_DURATION_SEC=60
+
+export SLEEP_TIME=10
+export SLEEP_GAP=10
+# In-window drain: time (s) after the client stops, before the window closes, so the
+# vendor/issuer returning to baseline is captured inside the plotted window.
+export DRAIN_TIME=30
+
+# Timestamp of this server-side benchmark execution (root folder for plots).
+RUN_TS="$(date '+%Y%m%d_%H%M%S')"
+
+# Current TPS/count for the active sweep iteration (set inside the loop).
+BENCHMARK_TARGET_TPS=0
+BENCHMARK_COUNT_VAR=0
+
+# Per-mode timing entries, joined into the timing JSON at the end.
+TIMING_ENTRIES=()
+
+# Aggregate exit status: becomes non-zero if any benchmark mode fails, while
+# still allowing subsequent modes to run.
+OVERALL_STATUS=0
+
+# run_mode <mode>: run the already-configured client once and record its window.
+# The caller must have exported CLIENT_PAYMENT_MODE and any mode-specific vars.
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+run_mode() {
+  local mode="$1"
+  local start end status=0
+
+  # The run_<mode> callers source envs/client.env.sh just before calling this,
+  # and that file may define CLIENT_TARGET_TPS. Exporting it here (after that
+  # source) makes this benchmark's target win over the env file's value.
+  export CLIENT_TARGET_TPS=$BENCHMARK_TARGET_TPS
+
+  log "=== [$mode] starting benchmark run (tps=$BENCHMARK_TARGET_TPS, count=$BENCHMARK_COUNT_VAR) ==="
+
+  log "[$mode] pre-run gap: sleeping ${SLEEP_GAP}s"
+  sleep "$SLEEP_GAP"
+
+  log "[$mode] launching client container"
+  # start_ms/finish_ms recorded here become the Prometheus query window the
+  # plotter reads. Take start after the pre-run sleep, when traffic actually
+  # begins, so the window covers the run itself and not SLEEP_GAP seconds of idle.
+  start=$(date +%s%3N)
+  # Capture the client exit status without letting `set -e` abort the script,
+  # so cleanup always runs and the timing entry is always recorded.
+  docker compose up --no-deps --abort-on-container-exit --exit-code-from client client || status=$?
+  log "[$mode] client container exited with status $status"
+
+  docker compose stop client >/dev/null 2>&1 || true
+  docker compose rm -fsv client >/dev/null 2>&1 || true
+
+  log "[$mode] drain gap: sleeping ${DRAIN_TIME}s"
+  sleep "$DRAIN_TIME"
+  end=$(date +%s%3N)
+
+  # Same rationale as run_benchmark.sh: leave the vendor keyspace empty so the
+  # next run does not inherit this one's dataset, and the benchmark does not
+  # leave it behind. After the window closes, so the reclaim is not measured.
+  log "[$mode] flushing vendor datastore"
+  docker compose exec -T redis-vendor redis-cli flushall >/dev/null || true
+
+  local result="success"
+  if [ "$status" -ne 0 ]; then
+    result="failed"
+    OVERALL_STATUS=1
+  fi
+  log "=== [$mode] finished: $result (window ${start}ms -> ${end}ms) ==="
+  TIMING_ENTRIES+=("{\"mode\":\"$mode\",\"tps\":$BENCHMARK_TARGET_TPS,\"total_requests\":$BENCHMARK_COUNT_VAR,\"status\":\"$result\",\"prometheus_timestamps\":{\"start_ms\":$start,\"finish_ms\":$end}}")
+}
+
+run_signature() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="signature"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  run_mode "signature"
+}
+
+run_paytree() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="paytree"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
+  export CLIENT_CHANNEL_AMOUNT=10000000
+  run_mode "paytree"
+}
+
+run_paytree_first_opt() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="paytree_first_opt"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
+  export CLIENT_CHANNEL_AMOUNT=10000000
+  run_mode "paytree_first_opt"
+}
+
+run_paytree_child_pair() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="paytree_child_pair"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYTREE_MAX_I=$BENCHMARK_COUNT_VAR
+  # Ensure channel_amount >= (max_i * unit_value) with headroom for remainder.
+  export CLIENT_CHANNEL_AMOUNT=10000000
+  run_mode "paytree_child_pair"
+}
+
+run_payword() {
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="payword"
+  export CLIENT_PAYMENT_COUNT=$BENCHMARK_COUNT_VAR
+  export CLIENT_PAYWORD_MAX_K=$BENCHMARK_COUNT_VAR
+  # Ensure channel_amount >= (max_k * unit_value) with headroom for remainder.
+  export CLIENT_CHANNEL_AMOUNT=10000000
+  run_mode "payword"
+}
+
+log "Building client image (tps_values=${TPS_VALUES[*]}, duration=${RUN_DURATION_SEC}s)"
+# Build the client image so the run uses current code (incl. the TPS delay plumbing).
+docker compose build client
+
+log "Server run timestamp: $RUN_TS"
+
+for tps in "${TPS_VALUES[@]}"; do
+  BENCHMARK_TARGET_TPS=$tps
+  BENCHMARK_COUNT_VAR=$((tps * RUN_DURATION_SEC))
+  log "=== Sweep iteration: tps=$BENCHMARK_TARGET_TPS count=$BENCHMARK_COUNT_VAR ==="
+
+  run_signature
+  sleep "$SLEEP_TIME"
+  run_paytree
+  sleep "$SLEEP_TIME"
+  run_paytree_first_opt
+  sleep "$SLEEP_TIME"
+  run_paytree_child_pair
+  sleep "$SLEEP_TIME"
+  run_payword
+  sleep "$SLEEP_TIME"
+done
+
+log "All modes complete, writing benchmark_timing.json"
+# Join the entries with commas and write the timing JSON as an object with
+# server_run_timestamp + runs (the plotter sweep module consumes this shape).
+RUNS_JSON="[$(IFS=,; echo "${TIMING_ENTRIES[*]}")]"
+jq -n --arg ts "$RUN_TS" --argjson runs "$RUNS_JSON" \
+  '{server_run_timestamp: $ts, runs: $runs}' > benchmark_timing.json
+
+if [ "$OVERALL_STATUS" -eq 0 ]; then
+  log "Benchmark run finished successfully"
+else
+  log "Benchmark run finished with failures"
+fi
+
+# Best-effort plot generation: do not override the benchmark exit status.
+log "Generating sweep plots from benchmark_timing.json"
+if poetry run python -m bench_plotter.sweep benchmark_timing.json; then
+  log "Sweep plots generated successfully"
+else
+  log "Sweep plot generation failed (benchmark exit status unchanged)"
+fi
+
+# Propagate a non-zero exit code if any benchmark mode failed.
+exit $OVERALL_STATUS

--- a/run_tps_saturation_sweep.sh
+++ b/run_tps_saturation_sweep.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+# Find the throughput ceiling of ONE sequential client.
+#
+# A NanoMoni client sends payments in a single sequential await loop, so its
+# ceiling is 1/round_trip_latency. Its pacer only ever *delays* a payment -- once
+# the loop is running late the sleep is simply skipped, and nothing reports the
+# shortfall. So a run asking for 4000 TPS that can only manage 1000 still exits 0
+# and looks exactly like a run that hit its target.
+#
+# This sweep makes that visible: it doubles the target TPS past the ceiling, then
+# has the plotter read back the rate the vendor actually served and chart expected
+# vs real. Where the curve leaves the diagonal is the saturation point.
+#
+# Unlike run_benchmark.sh this measures only throughput fidelity, so the runs and
+# gaps are short and no resource/latency plots are produced.
+
+# Doubling sweep: each step is compared against the ideal diagonal, so the knee
+# is bracketed within a factor of 2 no matter where it falls. The top two rungs
+# give headroom for CLIENT_VIRTUAL_CLIENTS > 1 runs to show a ceiling above what
+# a single virtual client could reach; harmless (just extra runtime) otherwise.
+TPS_VALUES=(16384)
+
+# Virtual-client fan-out for this sweep (own keypair + channel + payment loop
+# each, plus its own vendor connection). Kept a multiple of VENDOR_API_WORKERS:
+# each virtual client stays on the worker that accepted its connection, so a
+# count that does not divide by the worker count leaves some workers carrying an
+# extra client and capping the measured ceiling.
+CLIENT_VIRTUAL_CLIENTS=96
+
+# Every mode: the ceiling is a property of per-payment cost, so each has its own,
+# and the chart draws one line per mode. Same order as run_benchmark.sh.
+MODES=(signature paytree paytree_first_opt paytree_child_pair payword)
+
+# Seconds of traffic per run. Each run sends (TPS * RUN_DURATION_SEC) payments, so
+# a run that cannot keep up takes proportionally LONGER -- that overshoot is the
+# signal we are measuring. Must stay well above the plotter's rate() window
+# (_RATE_WINDOW in bench_plotter/saturation/aggregate.py), because traffic shorter
+# than that window reads low by (span / window) no matter how the client did; the
+# report flags such runs as UNMEASURABLE.
+RUN_DURATION_SEC=90
+
+# Idle gap before a run (lets the vendor return to baseline, and the previous
+# run's container finish being removed) and after it (lets Prometheus scrape the
+# final counter increments before the window closes).
+SLEEP_GAP=10
+DRAIN_TIME=5
+
+TIMING_FILE=tps_saturation_timing.json
+
+RUN_TS="$(date '+%Y%m%d_%H%M%S')"
+TIMING_ENTRIES=()
+OVERALL_STATUS=0
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# configure_mode <mode> <count>: export the client env for one run.
+configure_mode() {
+  local mode="$1" count="$2"
+
+  # Sourced first because it may define CLIENT_TARGET_TPS; the caller's target is
+  # exported after this so it wins. It also generates CLIENT_PRIVATE_KEY_PEMS
+  # (one key per CLIENT_VIRTUAL_CLIENTS, set above).
+  source envs/client.env.sh
+  export CLIENT_PAYMENT_MODE="$mode"
+  export CLIENT_PAYMENT_COUNT="$count"
+
+  # The runner splits CLIENT_PAYMENT_COUNT across CLIENT_VIRTUAL_CLIENTS, and each
+  # virtual client opens its own channel, so the commitment caps below size ONE
+  # client's tree/chain. Passing the sweep-wide count here would make every client
+  # build a commitment CLIENT_VIRTUAL_CLIENTS times larger than it can spend.
+  local per_client_count=$((count / CLIENT_VIRTUAL_CLIENTS))
+
+  case "$mode" in
+    paytree | paytree_first_opt | paytree_child_pair)
+      export CLIENT_PAYTREE_MAX_I="$per_client_count"
+      # channel_amount must cover (max_i * unit_value) with headroom.
+      export CLIENT_CHANNEL_AMOUNT=10000000
+      ;;
+    payword)
+      export CLIENT_PAYWORD_MAX_K="$per_client_count"
+      export CLIENT_CHANNEL_AMOUNT=10000000
+      ;;
+    signature) ;;
+    *)
+      log "unknown mode '$mode'"
+      return 1
+      ;;
+  esac
+}
+
+# run_one <mode> <tps> <count>: run the client once and record its window.
+run_one() {
+  local mode="$1" tps="$2" count="$3"
+  local start end status=0
+
+  configure_mode "$mode" "$count"
+  export CLIENT_TARGET_TPS="$tps"
+
+  log "=== [$mode] target=${tps} TPS, count=${count}, clients=${CLIENT_VIRTUAL_CLIENTS} (ideal ${RUN_DURATION_SEC}s of traffic) ==="
+
+  # Every mode starts from an empty keyspace. Nothing deletes channels, states or
+  # merkle nodes after a run, so without this each mode inherits every earlier
+  # one: more memory, and an AOF whose rewrites grow with the accumulated dataset
+  # while the run is in flight. That penalty lands on whichever mode happens to
+  # run last, which is not a property of the mode. Done before the gap so the
+  # reclaim and the rewrite it triggers settle before traffic starts.
+  log "[$mode] flushing both datastores"
+  docker compose exec -T redis-vendor redis-cli flushall >/dev/null || true
+  docker compose exec -T redis-issuer redis-cli flushall >/dev/null || true
+
+  log "[$mode] pre-run gap: sleeping ${SLEEP_GAP}s"
+  sleep "$SLEEP_GAP"
+
+  # start/end bound the Prometheus query window the plotter reads back.
+  start=$(date +%s%3N)
+  docker compose up --no-deps --abort-on-container-exit --exit-code-from client client || status=$?
+  log "[$mode] client exited with status $status"
+
+  docker compose stop client >/dev/null 2>&1 || true
+  docker compose rm -fsv client >/dev/null 2>&1 || true
+
+  log "[$mode] drain gap: sleeping ${DRAIN_TIME}s"
+  sleep "$DRAIN_TIME"
+  end=$(date +%s%3N)
+
+  local result="success"
+  if [ "$status" -ne 0 ]; then
+    result="failed"
+    OVERALL_STATUS=1
+  fi
+  local elapsed=$(((end - start) / 1000))
+  log "=== [$mode] target=${tps} finished: $result in ${elapsed}s, clients=${CLIENT_VIRTUAL_CLIENTS} ==="
+  TIMING_ENTRIES+=("{\"mode\":\"$mode\",\"tps\":$tps,\"total_requests\":$count,\"status\":\"$result\",\"prometheus_timestamps\":{\"start_ms\":$start,\"finish_ms\":$end}}")
+}
+
+log "Building client image so the run uses current code"
+docker compose build client
+
+log "Sweep: modes=[${MODES[*]}] targets=[${TPS_VALUES[*]}] duration=${RUN_DURATION_SEC}s clients=${CLIENT_VIRTUAL_CLIENTS} run_ts=$RUN_TS"
+
+for mode in "${MODES[@]}"; do
+  for tps in "${TPS_VALUES[@]}"; do
+    run_one "$mode" "$tps" "$((tps * RUN_DURATION_SEC))"
+  done
+done
+
+log "Writing $TIMING_FILE"
+RUNS_JSON="[$(IFS=,; echo "${TIMING_ENTRIES[*]}")]"
+jq -n --arg ts "$RUN_TS" --argjson runs "$RUNS_JSON" \
+  --argjson virtual_clients "$CLIENT_VIRTUAL_CLIENTS" \
+  '{server_run_timestamp: $ts, runs: $runs, virtual_clients: $virtual_clients}' > "$TIMING_FILE"
+
+if [ "$OVERALL_STATUS" -eq 0 ]; then
+  log "All runs completed"
+else
+  log "Some runs failed (see above)"
+fi
+
+# Best-effort report: do not override the benchmark exit status.
+log "Generating expected-vs-real TPS chart"
+if poetry run python -m bench_plotter.saturation "$TIMING_FILE"; then
+  log "Saturation report generated"
+else
+  log "Saturation report failed (benchmark exit status unchanged)"
+fi
+
+exit $OVERALL_STATUS

--- a/scripts/probe-saturation.py
+++ b/scripts/probe-saturation.py
@@ -1,0 +1,183 @@
+"""Attribute a saturated run to one component, in one snapshot.
+
+Runs on the host during the plateau of a benchmark:
+
+    poetry run python scripts/probe-saturation.py [window_seconds]
+
+Prints the rate the vendor is serving, the latency at that rate, the CPU each
+container spends per payment, and the split of the Redis serving thread across
+the commands it runs. The point is the per-payment column: a container at its
+cpuset ceiling only says it ran out of cores, while CPU per payment says how much
+of that ceiling one payment costs and therefore which component the next core
+would help. `scripts/probe-worker-connections.py` covers the vendor's internal
+split, which the container total also hides.
+
+Redis command accounting resets `commandstats` and reads it back after the
+window, so run this while traffic is steady -- a window that spans the start or
+end of a run mixes the ramp into the averages.
+"""
+
+import json
+import subprocess
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+# The metric names do not follow the mode names -- "paytree" is "paytree_std" on
+# the wire and "signature" uses the unprefixed counter of the original payment
+# router -- so both maps come from bench_plotter, which the plotters already read
+# them from. A second copy here would be one more place to drift.
+from bench_plotter.metric_queries import (
+    LATENCY_BUCKET_METRIC_BY_MODE,
+    PAYMENT_COUNTER_METRIC_BY_MODE,
+)
+
+PROMETHEUS = "http://localhost:9090/api/v1/query"
+REDIS_CONTAINER = "nanomoni-redis-vendor-1"
+SERVICES = ("vendor", "client", "redis-vendor", "issuer", "redis-issuer")
+
+# A mode whose counter moves slower than this is residual traffic from a previous
+# run being scraped, not the run under test.
+MIN_RATE = 50.0
+
+
+def query(expr):
+    url = PROMETHEUS + "?" + urllib.parse.urlencode({"query": expr})
+    with urllib.request.urlopen(url, timeout=15) as response:
+        return json.load(response)["data"]["result"]
+
+
+def scalar(expr):
+    result = query(expr)
+    if not result:
+        return None
+    value = float(result[0]["value"][1])
+    return None if value != value else value  # NaN means no samples in the window
+
+
+def rate_of(counter, window, *, succeeded):
+    match = "=" if succeeded else "!="
+    return scalar(f'sum(rate({counter}{{status{match}"success"}}[{window:g}s]))')
+
+
+def detect_mode(window):
+    """The mode whose payment counter is moving, and the rate it moves at."""
+    rates = {}
+    for mode, counter in PAYMENT_COUNTER_METRIC_BY_MODE.items():
+        rate = rate_of(counter, window, succeeded=True)
+        if rate is not None and rate > MIN_RATE:
+            rates[mode] = rate
+    if not rates:
+        return None, 0.0
+    return max(rates.items(), key=lambda item: item[1])
+
+
+def container_cores():
+    expr = (
+        "sum by (container_label_com_docker_compose_service) "
+        '(rate(container_cpu_usage_seconds_total{job="cadvisor",image!=""}[1m]))'
+    )
+    cores = {}
+    for row in query(expr):
+        service = row["metric"].get("container_label_com_docker_compose_service")
+        if service in SERVICES:
+            cores[service] = float(row["value"][1])
+    return cores
+
+
+def redis(*args):
+    return subprocess.run(
+        ["docker", "exec", REDIS_CONTAINER, "redis-cli", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def redis_info(section):
+    values = {}
+    for line in redis("info", section).splitlines():
+        if ":" in line and not line.startswith("#"):
+            key, value = line.split(":", 1)
+            values[key.strip()] = value.strip()
+    return values
+
+
+def redis_commands():
+    """calls and total microseconds per command, from cmdstat_ lines."""
+    stats = {}
+    for key, value in redis_info("commandstats").items():
+        if not key.startswith("cmdstat_"):
+            continue
+        fields = dict(field.split("=", 1) for field in value.split(","))
+        stats[key[len("cmdstat_") :]] = (int(fields["calls"]), float(fields["usec"]))
+    return stats
+
+
+WINDOW = float(sys.argv[1]) if len(sys.argv) > 1 else 12.0
+
+redis("config", "resetstat")
+cpu_before = redis_info("cpu")
+time.sleep(WINDOW)
+cpu_after = redis_info("cpu")
+commands = redis_commands()
+
+mode, rate = detect_mode(WINDOW)
+if mode is None:
+    print(f"no mode above {MIN_RATE:g} payments/s -- is a run in flight?")
+    sys.exit(1)
+
+counter = PAYMENT_COUNTER_METRIC_BY_MODE[mode]
+print(f"window {WINDOW:g}s  mode {mode}  achieved {rate:.0f} payments/s")
+
+# A payment the vendor rejected still cost it a request, and the client retries it,
+# so CPU spent here never reaches the success counter above.
+failed = rate_of(counter, WINDOW, succeeded=False)
+if failed:
+    print(f"rejected {failed:.0f} requests/s ({failed / (rate + failed):.1%} of all)")
+
+buckets = LATENCY_BUCKET_METRIC_BY_MODE[mode]
+quantiles = []
+for quantile in (0.5, 0.95, 0.99):
+    value = scalar(
+        f"histogram_quantile({quantile}, sum(rate({buckets}[{WINDOW:g}s])) by (le))"
+    )
+    if value is not None:
+        quantiles.append(f"p{int(quantile * 100)} {value:.1f} ms")
+in_flight = scalar(f"sum({counter.removesuffix('_total')}_inprogress)")
+if in_flight is not None:
+    quantiles.append(f"in flight {in_flight:.0f}")
+if quantiles:
+    print("latency " + "  ".join(quantiles))
+
+print(f"\n{'container':<14} {'cores':>7} {'µs/payment':>11}")
+for service, cores in sorted(container_cores().items()):
+    print(f"{service:<14} {cores:>7.2f} {cores / rate * 1e6:>11.0f}")
+
+
+def delta(key):
+    return float(cpu_after.get(key, 0.0)) - float(cpu_before.get(key, 0.0))
+
+
+serving = (delta("used_cpu_user") + delta("used_cpu_sys")) / WINDOW
+children = (delta("used_cpu_user_children") + delta("used_cpu_sys_children")) / WINDOW
+print(
+    f"\nredis serving thread {serving:.2f} of its 1.00 core ceiling"
+    f" ({serving / rate * 1e6:.0f} µs/payment), children {children:.2f}"
+)
+
+print(
+    f"\n{'command':<12} {'calls/s':>9} {'per payment':>12} {'µs/call':>9} {'cores':>7}"
+)
+for name, (calls, usec) in sorted(commands.items(), key=lambda item: -item[1][1]):
+    if calls == 0:
+        continue
+    print(
+        f"{name:<12} {calls / WINDOW:>9.0f} {calls / (rate * WINDOW):>12.2f} "
+        f"{usec / calls:>9.1f} {usec / WINDOW / 1e6:>7.3f}"
+    )
+print(
+    "\na command called from Lua is counted on its own and inside the EVALSHA that\n"
+    "called it, so the cores column does not sum to the serving thread above"
+)

--- a/scripts/probe-worker-connections.py
+++ b/scripts/probe-worker-connections.py
@@ -1,0 +1,133 @@
+"""Map established vendor connections to the Uvicorn worker holding each one.
+
+Runs inside the vendor container, where the connections live:
+
+    docker cp scripts/probe-worker-connections.py nanomoni-vendor-1:/tmp/probe.py
+    docker exec nanomoni-vendor-1 python /tmp/probe.py [cpu_window_seconds]
+
+Prints one line per worker with the port it listens on, its pinned core, its CPU
+utilization over a short window, and the connections it holds. Sampling it during
+a run shows whether a client stays on one worker and how evenly load landed
+across workers -- cadvisor only reports the container total, which hides a
+saturated worker sitting next to an idle one. Connections from Prometheus
+scraping /metrics show up here too, distinguishable by their peer address.
+"""
+
+import os
+import re
+import sys
+import time
+
+LISTEN = "0A"
+ESTABLISHED = "01"
+
+
+def _port(hex_addr):
+    return int(hex_addr.split(":")[1], 16)
+
+
+def read_tcp_table():
+    """Listening ports and established connections, both keyed by socket inode."""
+    listening = {}
+    established = {}
+    with open("/proc/net/tcp") as fh:
+        next(fh)
+        for line in fh:
+            parts = line.split()
+            local, remote, state, inode = parts[1], parts[2], parts[3], parts[9]
+            if state == LISTEN:
+                listening[inode] = _port(local)
+            elif state == ESTABLISHED:
+                established[inode] = (_port(local), remote)
+    # Only connections served by a socket we are listening on; outbound
+    # connections (Redis, issuer) share the table and are not interesting here.
+    ports = set(listening.values())
+    established = {i: v for i, v in established.items() if v[0] in ports}
+    return listening, established
+
+
+def worker_pids():
+    pids = []
+    for entry in os.listdir("/proc"):
+        if not entry.isdigit():
+            continue
+        try:
+            with open(f"/proc/{entry}/cmdline", "rb") as fh:
+                cmd = fh.read().decode(errors="replace")
+        except OSError:
+            continue
+        if "spawn_main" in cmd or "nanomoni.main" in cmd:
+            pids.append(entry)
+    return sorted(pids, key=int)
+
+
+def sockets_of(pid):
+    found = set()
+    fd_dir = f"/proc/{pid}/fd"
+    try:
+        entries = os.listdir(fd_dir)
+    except OSError:
+        return found
+    for fd in entries:
+        try:
+            target = os.readlink(f"{fd_dir}/{fd}")
+        except OSError:
+            continue
+        match = re.fullmatch(r"socket:\[(\d+)\]", target)
+        if match:
+            found.add(match.group(1))
+    return found
+
+
+def affinity_of(pid):
+    try:
+        return sorted(os.sched_getaffinity(int(pid)))
+    except OSError:
+        return []
+
+
+def cpu_jiffies(pid):
+    """utime + stime for a pid, or None if it went away."""
+    try:
+        with open(f"/proc/{pid}/stat") as fh:
+            fields = fh.read().rsplit(") ", 1)[1].split()
+    except (OSError, IndexError):
+        return None
+    return int(fields[11]) + int(fields[12])
+
+
+CPU_WINDOW_S = float(sys.argv[1]) if len(sys.argv) > 1 else 5.0
+HERTZ = os.sysconf("SC_CLK_TCK")
+
+pids = worker_pids()
+before = {pid: cpu_jiffies(pid) for pid in pids}
+time.sleep(CPU_WINDOW_S)
+after = {pid: cpu_jiffies(pid) for pid in pids}
+
+listening, established = read_tcp_table()
+total = 0
+busy_total = 0.0
+for pid in pids:
+    held = sockets_of(pid)
+    ports = sorted({listening[i] for i in held & listening.keys()})
+    conns = [established[i] for i in held & established.keys()]
+    start, end = before.get(pid), after.get(pid)
+    busy = (
+        (end - start) / HERTZ / CPU_WINDOW_S
+        if start is not None and end is not None
+        else float("nan")
+    )
+    if not ports and not conns:
+        continue
+    total += len(conns)
+    busy_total += busy
+    peers = ",".join(sorted(remote for _, remote in conns))
+    listens = ",".join(str(p) for p in ports)
+    print(
+        f"worker pid={pid} port={listens} core={affinity_of(pid)} "
+        f"busy={busy:5.0%} conns={len(conns)} peers={peers}"
+    )
+print(
+    f"total established connections = {total}, "
+    f"summed worker CPU = {busy_total:.2f} cores over {CPU_WINDOW_S:g}s"
+)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
 docker compose up -d alloy pyroscope cadvisor grafana prometheus
 
 sleep 5

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,6 @@
+docker compose up -d alloy pyroscope cadvisor grafana prometheus
+
+sleep 5
+source ./envs/issuer.env.sh && docker compose up issuer -d --build
+sleep 5
+source ./envs/vendor.env.sh && docker compose up vendor -d --build

--- a/src/nanomoni/application/vendor/use_cases/payment.py
+++ b/src/nanomoni/application/vendor/use_cases/payment.py
@@ -97,69 +97,6 @@ class PaymentService:
         except ValidationError as e:
             raise ValueError(f"Invalid payment channel data from issuer: {e}")
 
-    async def _save_payment_with_retry(
-        self,
-        *,
-        channel_id: str,
-        payment_channel: SignaturePaymentChannel,
-        new_state: SignatureState,
-        is_first_payment: bool,
-    ) -> tuple[int, Optional[SignatureState], SignaturePaymentChannel]:
-        """
-        Save an off-chain payment, reconciling vendor cache races.
-
-        Repository status codes:
-          - 1: stored successfully (returns stored_tx)
-          - 0: rejected (race / not increasing; returns current tx or None)
-          - 2: channel missing in vendor cache (needs issuer verification)
-
-        """
-
-        # We may need up to two passes:
-        # - First attempt using current local knowledge.
-        # - If status==2, fetch from issuer, then retry initial-cache + save.
-        for attempt in range(2):
-            if is_first_payment:
-                (
-                    status,
-                    stored_state,
-                ) = await self.payment_channel_repository.save_channel_and_initial_payment(
-                    payment_channel, new_state
-                )
-                if status == 1:
-                    return status, stored_state, payment_channel
-
-                # status == 0: cache collision; switch to subsequent-save flow
-                is_first_payment = False
-                cached = await self.payment_channel_repository.get_by_channel_id(
-                    channel_id
-                )
-                if not cached:
-                    raise RuntimeError(
-                        "Race condition handling failed: channel missing after collision"
-                    )
-                if not isinstance(cached, SignaturePaymentChannel):
-                    raise TypeError("Cached channel is not signature-mode")
-                payment_channel = cached
-
-            status, stored_state = await self.payment_channel_repository.save_payment(
-                payment_channel, new_state
-            )
-
-            if status != 2:
-                return status, stored_state, payment_channel
-
-            # status == 2: vendor cache is missing the channel; fetch from issuer,
-            # then cache it and retry the save flow once.
-            if attempt == 0:
-                payment_channel = await self._verify_payment_channel(channel_id)
-                is_first_payment = True
-                continue
-
-        # If we get here, something is inconsistent (e.g., channel was verified
-        # but still appears missing in storage).
-        return status, stored_state, payment_channel
-
     async def receive_payment(self, dto: ReceivePaymentDTO) -> OffChainTxResponseDTO:
         """Receive and validate an off-chain payment from a client."""
         # 1) Get full channel aggregate (lazy load)
@@ -235,16 +172,62 @@ class PaymentService:
             created_at=datetime.now(timezone.utc),
         )
 
-        (
-            status,
-            stored_tx,
-            _payment_channel,
-        ) = await self._save_payment_with_retry(
-            channel_id=dto.channel_id,
-            payment_channel=payment_channel,
-            new_state=signature_state,
-            is_first_payment=is_first_payment,
-        )
+        # 7) Save with retry, reconciling vendor cache races.
+        #
+        # Repository status codes:
+        #   - 1: stored successfully (returns stored_tx)
+        #   - 0: rejected (race / not increasing; returns current tx or None)
+        #   - 2: channel missing in vendor cache (needs issuer verification)
+        #
+        # Inlined as sibling calls (matching payword/paytree's retry shape)
+        # rather than a nested wrapper: every repository call here sits
+        # directly under receive_payment, so CPU-time profiling attributes
+        # each one to the same leaf name at the same depth, instead of
+        # nesting a second get_by_channel_id/issuer-HTTP call inside another
+        # db-bucket function.
+        #
+        # Up to two passes: first attempt using current local knowledge; if
+        # status==2, fetch from issuer, then retry initial-cache + save.
+        status: int
+        stored_tx: Optional[SignatureState]
+        for attempt in range(2):
+            if is_first_payment:
+                (
+                    status,
+                    stored_tx,
+                ) = await self.payment_channel_repository.save_channel_and_initial_payment(
+                    payment_channel, signature_state
+                )
+                if status == 1:
+                    break
+
+                # status == 0: cache collision; switch to subsequent-save flow
+                is_first_payment = False
+                cached = await self.payment_channel_repository.get_by_channel_id(
+                    dto.channel_id
+                )
+                if not cached:
+                    raise RuntimeError(
+                        "Race condition handling failed: channel missing after collision"
+                    )
+                if not isinstance(cached, SignaturePaymentChannel):
+                    raise TypeError("Cached channel is not signature-mode")
+                payment_channel = cached
+
+            status, stored_tx = await self.payment_channel_repository.save_payment(
+                payment_channel, signature_state
+            )
+
+            if status != 2:
+                break
+
+            # status == 2: vendor cache is missing the channel; fetch from
+            # issuer, then cache it and retry the save flow once.
+            if attempt == 0:
+                payment_channel = await self._verify_payment_channel(dto.channel_id)
+                is_first_payment = True
+                continue
+            break
 
         if status == 1:
             # Success: transaction was stored

--- a/src/nanomoni/infrastructure/vendor/payment_repository_impl.py
+++ b/src/nanomoni/infrastructure/vendor/payment_repository_impl.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Optional
 
+from pydantic import ValidationError
+
 from ...domain.shared.crypto_proof import CryptoProof
 from ...domain.vendor.entities import PaymentChannel, PaymentState
 from ...domain.vendor.payment_repository import PaymentRepository
@@ -14,14 +16,28 @@ from .payment_channel_repository_base_impl import PaymentChannelRepositoryBaseIm
 class PaymentRepositoryImpl(PaymentChannelRepositoryBaseImpl, PaymentRepository):
     """KeyValueStore implementation for unified PaymentChannel + PaymentState."""
 
+    def _parse_channel(self, raw: str) -> Optional[PaymentChannel]:
+        """Parse a stored channel in a single pass.
+
+        Every channel this repository owns is a ``PaymentChannel``, so it can
+        validate straight from JSON instead of going through the base class's
+        ``_deserialize_channel``, which spends an extra Python ``json.loads``
+        pass just to read ``scheme`` and pick a model. Anything that isn't a
+        proof-based channel falls back to that dispatch, which distinguishes a
+        signature-mode channel stored under the same key (not found, as before)
+        from genuinely corrupt data (raises, as before).
+        """
+        try:
+            return PaymentChannel.model_validate_json(raw)
+        except ValidationError:
+            channel = self._deserialize_channel(raw)
+            return channel if isinstance(channel, PaymentChannel) else None
+
     async def get_channel(self, channel_id: str) -> Optional[PaymentChannel]:
         raw = await self.store.get(f"payment_channel:{channel_id}")
         if not raw:
             return None
-        channel = self._deserialize_channel(raw)
-        if not isinstance(channel, PaymentChannel):
-            return None
-        return channel
+        return self._parse_channel(raw)
 
     async def get_state(self, channel_id: str) -> Optional[PaymentState]:
         raw = await self.store.get(f"payment_state:{channel_id}")
@@ -35,11 +51,7 @@ class PaymentRepositoryImpl(PaymentChannelRepositoryBaseImpl, PaymentRepository)
         channel_raw, state_raw = await self.store.mget(
             [f"payment_channel:{channel_id}", f"payment_state:{channel_id}"]
         )
-        channel: Optional[PaymentChannel] = None
-        if channel_raw:
-            c = self._deserialize_channel(channel_raw)
-            if isinstance(c, PaymentChannel):
-                channel = c
+        channel = self._parse_channel(channel_raw) if channel_raw else None
         state: Optional[PaymentState] = None
         if state_raw:
             state = PaymentState.model_validate_json(state_raw)
@@ -68,9 +80,17 @@ class PaymentRepositoryImpl(PaymentChannelRepositoryBaseImpl, PaymentRepository)
         if code == 1:
             return 1, new_state
         if code == 0:
+            # The script's stale branch returns only the previous ref
+            # (tostring(prev)), not the full state, so reconstructing the
+            # current PaymentState needs this extra read.
             return 0, await self.get_state(channel.channel_id)
         if code == 3:
-            return 3, await self.get_state(channel.channel_id)
+            # Unlike the stale branch, the capacity-exceeded branch already
+            # returns the full current state JSON (or '' if none), so it can
+            # be parsed directly instead of spending a second round trip.
+            raw = result[1] if result and len(result) > 1 else None
+            state = PaymentState.model_validate_json(raw) if raw else None
+            return 3, state
         return 2, None
 
     async def save_channel_and_initial_state(

--- a/tuning.md
+++ b/tuning.md
@@ -35,11 +35,18 @@ Everything below is specific to the box the sweep runs on: an AMD EPYC 9224
 (Zen 4), 24 cores and 48 threads on a single socket, presented as one NUMA node.
 Its cores are grouped into L3/CCX clusters of six — `6-11`, `12-17`, `18-23`,
 and so on — and each physical core exposes an SMT sibling at `N+24`. The
-`docker-compose.yml` pinning follows that topology deliberately: the vendor sits
-on core `6` next to its Redis on `7`, the issuer on `8` beside its Redis on `9`,
-so each service shares an L3 with its own datastore. The load generator runs on
-core `12`, a separate CCX, so it never competes with the services it drives, and
-the entire monitoring stack is banished to `18-23`. The kernel is 6.8, which
+The `docker-compose.yml` pinning gives the vendor as much of that machine as it
+can take without contending with anything that would distort the measurement: it
+holds `1-10,19-20`, twelve physical cores, one per uvicorn worker. What is left out
+is deliberate — `11` and `18` for its own Redis, `12-14,21` for the load generator,
+`16` and `17` for the issuer and its Redis, `22-23` for the monitoring stack, and
+`0` plus `15` for housekeeping and interrupts. Those exclusions are the reason the vendor is
+pinned at all rather than left unconstrained: `cpuset` cannot reserve a core, so
+an unpinned vendor would spread straight onto them, and time stolen from a
+sequential client loop reads back as vendor latency that no plot can attribute
+correctly. The split between the two sides follows one rule — the vendor gets at
+least three cores per client core, here twelve against four — so the ceiling a sweep
+finds belongs to the server and not to the generator. The kernel is 6.8, which
 matters later because it ships the EEVDF scheduler in place of CFS.
 
 ## What the plots are actually showing
@@ -107,7 +114,7 @@ Disabling it holds the hot cores in C1 at most, which they exit in a
 microsecond, so a request never again pays the 800-microsecond wake-up.
 
 ```bash
-for c in 6 7 8 9 12 18 19 20 21 22 23; do
+for c in $(seq 1 23); do
   echo 1 | sudo tee /sys/devices/system/cpu/cpu$c/cpuidle/state2/disable
 done
 ```
@@ -150,18 +157,31 @@ point of the benchmark — is unaffected.
 ### Pin interrupts away from the hot cores
 
 Steering every IRQ onto the housekeeping cores keeps interrupt handling off the
-cores running the services.
+cores running the services. Growing the vendor to ten cores shrank that
+housekeeping set to two, `0` and `15`, which is why core `0` is excluded from the
+vendor in the first place — the boot CPU is the one core the kernel is least
+willing to give up, so it is the natural place to send the interrupts.
 
 ```bash
-# per-IRQ files take a core list (0-5); default_smp_affinity takes a hex mask
-# (cores 0-5 = 0b111111 = 3f)
-for irq in /proc/irq/*/smp_affinity_list; do echo 0-5 | sudo tee "$irq" 2>/dev/null; done
-echo 3f | sudo tee /proc/irq/default_smp_affinity
+# per-IRQ files take a core list; default_smp_affinity takes a hex mask
+# cores 0 and 15 = bit 0 | bit 15 = 8001
+for irq in /proc/irq/*/smp_affinity_list; do echo 0,15 | sudo tee "$irq" 2>/dev/null; done
+echo 8001 | sudo tee /proc/irq/default_smp_affinity
 ```
 
-**Pros:** removes interrupt jitter from the benchmark cores; no reboot; cheap.
-**Cons:** concentrates all interrupt load on `0-5`, so those cores must stay free
-for housekeeping; some IRQs pin back to their default on device or driver reload.
+Two cores is thin for a machine-wide IRQ load, but less thin than it looks for
+this benchmark: the traffic never crosses a physical NIC. Client, vendor, and
+issuer talk over a Docker bridge, where packet processing happens in softirq
+context on the CPU that queued the packet rather than through a device interrupt,
+and `smp_affinity` has no say over that. What this step actually removes is the
+unrelated device and timer interrupt noise, which two cores absorb comfortably.
+
+**Pros:** removes interrupt jitter from the vendor and client cores; no reboot;
+cheap.
+**Cons:** concentrates all device interrupt load on `0` and `15`, so those two
+must stay out of every service `cpuset`; some IRQs pin back to their default on
+device or driver reload; it does nothing for the bridge softirq work, which stays
+on the sending core by construction.
 
 ### Isolate the cores at the kernel level
 
@@ -183,6 +203,25 @@ across reboots by construction.
 **Cons:** requires a reboot; the isolated cores leave the general pool, and their
 RCU and timer work piles onto the housekeeping cores, which must be sized to
 absorb it; a mistake in the core list is only caught after the reboot.
+
+The list above predates the current pinning. What it should isolate now is the
+vendor and client cores together with their SMT siblings, leaving the housekeeping
+pair, the datastores, and the monitoring cores in the general pool to absorb the
+offloaded RCU and timer work:
+
+```
+isolcpus=1-14,25-38 nohz_full=1-14,25-38 rcu_nocbs=1-14,25-38 processor.max_cstate=1 nmi_watchdog=0 transparent_hugepage=never
+```
+
+Core `0` stays out on purpose. It is the boot CPU, several kernel facilities
+assume it is schedulable, and it is where the interrupt step above sends the IRQs.
+
+One trap comes with this step rather than from it. `isolcpus` makes an *unpinned*
+container worse off than a pinned one: the scheduler will not balance onto
+isolated cores, so a service with no `cpuset` is confined to the housekeeping
+cores instead of running anywhere. Dropping the vendor's `cpuset` to "give it
+every core" would, on an isolated boot, silently hand it the fewest — and nothing
+in the logs would say so.
 
 ### Disable SMT
 
@@ -218,33 +257,76 @@ dedicated, isolated bench box and never on anything exposed.
 Every host knob above only matters on the exact cores the containers run on, and
 `docker-compose.yml` is what decides that. The two layers are complementary:
 Docker gives *placement*, the host tuning gives *exclusivity and idle behavior*
-on the same cores. The pinning is already correct — `cpuset` puts the vendor on
-`6` beside its Redis on `7`, the issuer on `8` beside its Redis on `9` so each
-service shares an L3 with its own datastore, the load generator on `12` in a
-separate CCX, and the monitoring stack out on `18-23`. Every command in this
-document targets those same core numbers for exactly that reason. There are,
-however, three things the compose file cannot do on its own.
+on the same cores. The pinning is already correct — `cpuset` puts the vendor's twelve
+workers on `1-10,19-20` beside its Redis on `11` and `18`, the load generator's four
+processes on `12-14,21`, the issuer on `16` beside its Redis on `17`, and the
+monitoring stack out on `22-23`. Every command in this document targets those same core numbers for
+exactly that reason. There are, however, four things the compose file cannot do
+on its own.
 
-The first is exclusivity. `cpuset: "6"` keeps *that container* from wandering off
-core 6, but it does nothing to stop the kernel, another container, or a stray
-process from also scheduling onto core 6. Only `isolcpus` genuinely reserves a
+The first is exclusivity. `cpuset` keeps *that container* from wandering off its
+cores, but it does nothing to stop the kernel, another container, or a stray
+process from also scheduling onto them. Only `isolcpus` genuinely reserves a
 core, which is why the Docker pinning and the kernel-level isolation are two
 halves of the same fix rather than alternatives.
 
-The second is the SMT sibling. Pinning to hardware thread 6 leaves its sibling
+The second is one process per core. A `cpuset` of ten cores holding ten uvicorn
+workers still lets the scheduler shuffle those workers among the ten, and a worker
+that lands on a different core arrives with a cold L3. Affinity is per process, so
+this one is settled inside the container: `VENDOR_PIN_WORKERS_TO_CORES` has each
+worker claim a core of the `cpuset` for its lifetime as it starts up, and
+`CLIENT_PIN_PROCESSES_TO_CORES` does the same for the generator's processes. Claims
+are exclusive, so a `cpuset` smaller than the worker count leaves the surplus
+workers unpinned rather than doubled up — the startup log says which core each one
+took, or that it got none.
+
+Pinning only decides *where* a worker runs; work still has to reach it, and that
+is the other half of the same problem. Uvicorn's own multi-worker mode has every
+worker accept from one shared listening socket and lets the kernel pick, which is
+not the round-robin one might assume: measured with 40 client connections over ten
+workers, the spread was 1 to 7 connections per worker, the loaded ones sat at
+84-91% of their single core, two sat below 10%, and the vendor plateaued at 5400
+TPS while looking half idle at 5.5 of 10 cores. So the vendor instead runs one
+single-worker server per port, `VENDOR_API_PORT` upward, one listening socket
+each, and the load generator dials port `base + (client index % CLIENT_VENDOR_PORT_COUNT)`.
+Because a keep-alive connection is served end to end by the worker that accepted
+it, choosing the port chooses the worker: the same 40 clients then landed exactly
+4 per worker, all ten between 81% and 91%, for 8.6 of 10 cores and 6800 TPS. Keep
+`CLIENT_VENDOR_PORT_COUNT` equal to `VENDOR_API_WORKERS` and the virtual-client
+count a multiple of it, or the arithmetic reintroduces the imbalance it removes.
+`scripts/probe-worker-connections.py` prints the per-worker connection and CPU
+split that cadvisor's container total hides.
+
+The third is the SMT sibling. Pinning to hardware thread 6 leaves its sibling
 30 — the other thread on the same physical core, sharing its execution units —
 free for anything to land on, and whatever lands there steals throughput from
 the vendor unpredictably. Docker has no way to express "reserve the sibling
 too," so this is handled at the host level by naming the `+24` siblings in the
 C-state and isolation steps, or by disabling SMT outright.
 
-The third is Redis persistence. Both Redis containers run `--appendonly yes`, so
+The fourth is Redis persistence. Both Redis containers run `--appendonly yes`, so
 the AOF `fsync` (default `everysec`) is a periodic background disk write sitting
 on the critical path — a source of occasional latency spikes unrelated to the
 payment logic. If durability is not part of what the benchmark measures,
 `--save "" --appendonly no` removes it entirely; if it is, `--appendfsync no`
 lets the OS flush on its own schedule and at least takes the `fsync` off the
 timed path.
+
+Keeping the AOF costs a core, which is why `redis-vendor` holds two. The rewrite
+is done by a forked child, and a fork inherits the `cpuset`: on a single core it
+competed head to head with the one thread that serves payments. Measured under
+`paytree_child_pair`, the core was pegged at 100% while `redis-server` itself
+accounted for only half of it — two `redis-server` processes sat on that core, the
+second appearing only for the duration of the run. Serving a payment costs Redis
+about 105 µs of CPU (two round-trips: one `MGET`, then one `EVALSHA` whose 72 µs
+covers all the writes, of which the `SET`/`ZADD`/`GET` calls are only ~23 µs), so
+the ceiling that reads back as "Redis is saturated" was mostly rewrite work. The
+second core comes from the monitoring block rather than from the vendor or the
+generator, and landing in another L3 is a feature: the rewrite streams the whole
+dataset and would otherwise evict the serving thread's cache. The other half of
+this is not a tuning knob at all — nothing deletes keys after a run, so the sweep
+flushes both datastores before each one, otherwise the rewrite each mode pays for
+is sized by every mode that ran before it.
 
 Two smaller notes: there are no `mem_limit`s, which is fine here — 257 GB free on
 a single NUMA node means no memory pressure and no cross-node variance to worry


### PR DESCRIPTION
## Summary
- New flamegraph/profiling subsystem on top of Pyroscope traces (`flamebearer.py`, `profiling/`, `plotting/flame_renderer.py`, `plotting/profile_bar_renderer.py`), with per-mode function-name mappings verified against live traces.
- New TPS-saturation sweep subsystem (`saturation/`) comparing target vs. achieved TPS from Prometheus, with a plateau sample-selection algorithm to exclude ramp-up/drain windows.
- `run_quick_benchmark.sh`, `run_tps_saturation_sweep.sh`, `scripts/probe-saturation.py`, `scripts/probe-worker-connections.py` drive/support the above.
- `prometheus.yml` scrape interval -> 1s (needed for the sweep's `rate([10s])` math); `alloy.config` eBPF sample rate 19->97/s.
- `docs/benchmark-ceiling-and-what-remains.md`: per-mode bottleneck writeup (Redis's single serving thread bounds payword/paytree/first_opt/child_pair; ECDSA verify bounds signature).
- Two signature-mode fixes surfaced by this profiling work, riding along since they don't fit either PR #70 or #71: `payment.py` inlines its save-with-retry helper so profiling attributes calls consistently with payword/paytree's shape, and `payment_repository_impl.py` parses a stored channel in one JSON pass instead of two.

## Depends on
Stacked on #71 (CPU affinity / worker scaling), which sets up the persistent Pyroscope storage (bind mount fix) this profiling tooling relies on.

## Not included
`scripts/analyze-db-bar.py` and `scripts/compare-save-payment.py` were one-off investigation scripts used while root-causing this work; left out of all three PRs pending a decision on whether they're worth keeping as permanent tooling.

## Test plan
- [ ] `cd bench-plotter && poetry run pytest`
- [ ] `bash scripts/lint.sh && poetry run mypy src/nanomoni`

🤖 Generated with [Claude Code](https://claude.com/claude-code)